### PR TITLE
Skip adding "Copy contents from" to untranslatable StreamField

### DIFF
--- a/wagtail_modeltranslation/fields.py
+++ b/wagtail_modeltranslation/fields.py
@@ -246,6 +246,7 @@ class TranslationField(object):
                 formfield = super(TranslationField, self).formfield(*args, **kwargs)
                 if isinstance(formfield.widget, (forms.TextInput, forms.Textarea)):
                     formfield.widget = ClearableWidgetWrapper(formfield.widget)
+        formfield.widget.attrs['data-language'] = self.language
         return formfield
 
     def save_form_data(self, instance, data, check=True):

--- a/wagtail_modeltranslation/static/modeltranslation/js/copy_stream_fields.js
+++ b/wagtail_modeltranslation/static/modeltranslation/js/copy_stream_fields.js
@@ -15,6 +15,12 @@ $(document).ready(function(){
     var lastUnderscore = fieldInfos.lastIndexOf("_");
     var fieldName = fieldInfos.substring(0, lastUnderscore);
     var fieldLang = fieldInfos.substring(lastUnderscore + 1, fieldInfos.length);
+    // Splitting up the field info failed to detect a language code, skip
+    // TODO: This needs a consistent way of detecting that a field is
+    // translatable
+    if (!fieldName || fieldLang.length != 2) {
+      continue;
+    }
 		//The cycle to create the buttons for copy each language field
 		var copyContentString = 'Copy content from';
 		header.innerHTML += '<div class="translation-field-copy-wrapper">'+copyContentString+': </div>';


### PR DESCRIPTION
I'm not sure how to consistently detect that a StreamField is translatable and it seems that current method wasn't very reliable.

For me, this quick fix avoids adding the copy buttons to untranslatable fields.. so it's fine for the moment.

On a related note, StreamField translation is borked on Wagtail 1.3.1 (javascript err: `blockOpts is undefined`) and unfortunately wagtail_modtranslation doesn't work for Wagtail 1.4 at all. I would like to help, but I'm afraid I don't understand the "magic" of Wagtails javascript.
