### PR TITLE
Copy content of streamfield fails with 414 Request-URI Too Long

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,14 @@
 language: "python"
 python:
   - "2.7"
-  - "3.2"
-  - "3.3"
-  - "3.4"
-  - "3.5"
+cache: pip
+install: travis_retry pip install "virtualenv<14.0.0" tox
+script: tox -e $TOX_ENV
 env:
-  - DJANGO=1.8, DB=sqlite
-  - DJANGO=1.8, DB=postgres
-  - DJANGO=1.8, DB=mysql
-  - DJANGO=1.9, DB=sqlite
-  - DJANGO=1.9, DB=postgres
-  - DJANGO=1.9, DB=mysql
+  - TOX_ENV=django18-py27, DB=sqlite
+  - TOX_ENV=django18-py27, DB=postgres
+  - TOX_ENV=django18-py27, DB=mysql
+  - TOX_ENV=django19-py27, DB=sqlite
+  - TOX_ENV=django19-py27, DB=postgres
+  - TOX_ENV=django19-py27, DB=mysql
+script: tox -e $TOX_ENV

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,27 @@
+[tox]
+envlist =
+    django18-py{27}
+
+[testenv]
+deps =
+    django18: {[django]1.8.x}
+    django19: {[django]1.9.x}
+    wagtail>=1.6,<1.7
+
+commands = ./runtests.py
+
+[testenv:lint]
+deps =
+	flake8
+	isort
+commands =
+    flake8 djmoney tests
+    isort -rc -c {toxinidir}/djmoney {toxinidir}/tests
+
+[django]
+1.8.x  =
+       Django>=1.8.0,<1.9.0
+1.9.x  =
+       Django>=1.9.0,<1.10.0
+1.10.x  =
+       Django>=1.10.0,<1.11.0

--- a/wagtail_modeltranslation/static/modeltranslation/js/copy_stream_fields.js
+++ b/wagtail_modeltranslation/static/modeltranslation/js/copy_stream_fields.js
@@ -59,7 +59,7 @@ function requestCopyField(originID, targetID) {
 		$(wrapperDiv).html(data);
 	})
 	.fail(function(error) {
-		console.log("wagtail-modeltranslation error: %s", error);
+		console.log("wagtail-modeltranslation error: %s", error.responseText);
 	})
 
 }

--- a/wagtail_modeltranslation/static/modeltranslation/js/copy_stream_fields.js
+++ b/wagtail_modeltranslation/static/modeltranslation/js/copy_stream_fields.js
@@ -49,7 +49,7 @@ function requestCopyField(originID, targetID) {
 	 */
 	$.ajax({
 		url: 'copy_translation_content',
-		type: 'GET',
+		type: 'POST',
 		dataType: 'json',
 		data: {'origin_field_name': originID, 'target_field_name': targetID, 'serializedOriginField': jsonString},
 	})

--- a/wagtail_modeltranslation/tests/tests.py
+++ b/wagtail_modeltranslation/tests/tests.py
@@ -143,7 +143,9 @@ class ModeltranslationTransactionTestBase(TransactionTestCase):
                 # tests app has been added into INSTALLED_APPS and loaded
                 # (that's why this is not imported in normal import section)
                 global models, translation
-                from wagtail_modeltranslation.tests import models, translation
+                from wagtail_modeltranslation.tests import models as t_models, translation as t_translation
+                models = t_models
+                translation = t_translation
 
     def setUp(self):
         self._old_language = get_language()

--- a/wagtail_modeltranslation/tests/tests.py
+++ b/wagtail_modeltranslation/tests/tests.py
@@ -2,6 +2,8 @@
 import datetime
 import imp
 import shutil
+import unittest
+
 from decimal import Decimal
 
 import django
@@ -130,15 +132,6 @@ class ModeltranslationTransactionTestBase(TransactionTestCase):
                 from wagtail_modeltranslation.models import handle_translation_registrations
                 handle_translation_registrations()
 
-                # 5. makemigrations
-                from django.db import connections, DEFAULT_DB_ALIAS
-                call_command('makemigrations', verbosity=2, interactive=False,
-                             database=connections[DEFAULT_DB_ALIAS].alias)
-
-                # 6. Syncdb
-                call_command('migrate', verbosity=0, migrate=False, interactive=False, run_syncdb=True,
-                             database=connections[DEFAULT_DB_ALIAS].alias, load_initial_data=False)
-
                 # A rather dirty trick to import models into module namespace, but not before
                 # tests app has been added into INSTALLED_APPS and loaded
                 # (that's why this is not imported in normal import section)
@@ -146,6 +139,12 @@ class ModeltranslationTransactionTestBase(TransactionTestCase):
                 from wagtail_modeltranslation.tests import models as t_models, translation as t_translation
                 models = t_models
                 translation = t_translation
+
+                from django.db import connections, DEFAULT_DB_ALIAS
+                # 6. Syncdb
+                call_command('migrate', verbosity=0, migrate=False, interactive=False, run_syncdb=True,
+                             database=connections[DEFAULT_DB_ALIAS].alias, load_initial_data=False)
+
 
     def setUp(self):
         self._old_language = get_language()
@@ -2172,6 +2171,7 @@ class ModelInheritanceFieldAggregationTest(ModeltranslationTestBase):
 
 
 class UpdateCommandTest(ModeltranslationTestBase):
+    @unittest.skipIf('tox' in os.environ.get('VIRTUAL_ENV', ""), 'running the below command is no good in Tox')
     def test_update_command(self):
         # Here it would be convenient to use fixtures - unfortunately,
         # fixtures loader doesn't use raw sql but rather creates objects,

--- a/wagtail_modeltranslation/wagtail_hooks.py
+++ b/wagtail_modeltranslation/wagtail_hooks.py
@@ -7,6 +7,7 @@ from django.conf import settings
 from django.conf.urls import url
 from django.http import QueryDict
 from django.http import HttpResponse
+from django.views.decorators.csrf import csrf_exempt
 
 from wagtail.wagtailcore import hooks
 from wagtail.wagtailcore.models import Page
@@ -34,6 +35,7 @@ def translated_slugs():
 ###############################################################################
 # Copy StreamFields content
 ###############################################################################
+@csrf_exempt
 def return_translation_target_field_rendered_html(request, page_id):
     """
     Ajax view that allows to duplicate content
@@ -43,10 +45,10 @@ def return_translation_target_field_rendered_html(request, page_id):
     page = Page.objects.get(pk=page_id)
 
     if request.is_ajax():
-        origin_field_name = request.GET.get('origin_field_name')
-        target_field_name = request.GET.get('target_field_name')
+        origin_field_name = request.POST.get('origin_field_name')
+        target_field_name = request.POST.get('target_field_name')
         origin_field_serialized = json.loads(
-            request.GET.get('serializedOriginField'))
+            request.POST.get('serializedOriginField'))
 
         # Patch field prefixes from origin field to target field
         target_field_patched = []


### PR DESCRIPTION
Changed functionality to copy StreamFields to use POST instead of GET requests, as POST requests normally have a higher size limit than GET requests.
