### PR TITLE
Redefine a custom edit_handler after patch tabs patch

### DIFF
--- a/wagtail_modeltranslation/translator.py
+++ b/wagtail_modeltranslation/translator.py
@@ -69,16 +69,19 @@ class TranslationOptions(with_metaclass(FieldsAggregationMetaClass, object)):
         """
         Create fields dicts without any translation fields.
         """
+        
         page_fields = ()
-
+        
+        self.page_fields = (
+            'title',
+            'slug',
+            'seo_title',
+            'search_description',
+            'url_path',)
+        
         if Page in model.__bases__:
-            page_fields = (
-                'title',
-                'slug',
-                'seo_title',
-                'search_description',
-                'url_path',)
-
+            page_fields = self.page_fields
+        
         self.model = model
         self.registered = False
         self.related = False
@@ -98,7 +101,8 @@ class TranslationOptions(with_metaclass(FieldsAggregationMetaClass, object)):
             else:
                 self._check_languages(self.required_languages.keys(), extra=('default',))
                 for fieldnames in self.required_languages.values():
-                    if any(f not in self.fields for f in fieldnames):
+                    checkfields = self.page_fields if self.model == Page else self.fields
+                    if any(f not in checkfields for f in fieldnames):
                         raise ImproperlyConfigured(
                             'Fieldname in required_languages which is not in fields option.')
 


### PR DESCRIPTION
Fix issue described here
https://github.com/infoportugal/wagtail-modeltranslation/issues/85

This modification requires a custom edit_handler must be defined differently as described in wagtail documentaion.

In the page model must be defined a 'edit_handler_set' function that sets the edit_handler attribute.
This function must be called after model definition. 
This function is also called by WagtailTranslator (patch_wagtailadmin.py)
