### PR TITLE
Fix broken url_paths on moving pages with descendants

### DIFF
--- a/wagtail_modeltranslation/patch_wagtailadmin.py
+++ b/wagtail_modeltranslation/patch_wagtailadmin.py
@@ -384,8 +384,9 @@ def _new_set_url_path(self, parent):
                 setattr(self, 'url_path', '/')
 
     # update url_path for children pages
-    for child in self.get_children():
+    for child in self.get_children().specific():
         child.set_url_path(self.specific)
+        child.save()
 
     return self.url_path
 


### PR DESCRIPTION
Fix issue #63

The patched _new_set_url_path was not working on specific objects and was not even saving them.

This patch works fine and should solve the same kind of problem when changing a slug on a page with descendants.

Anyway this may have some impact on performance since it's a save on every single object. It may be improved with a massive update, one per kind of specific model.