### PR TITLE
Override Page.move, not a subclassed move method

### DIFF
--- a/wagtail_modeltranslation/patch_wagtailadmin.py
+++ b/wagtail_modeltranslation/patch_wagtailadmin.py
@@ -97,8 +97,10 @@ class WagtailTranslator(object):
                         f.required = True
 
         # Overide page methods
-        if issubclass(model, Page):
+        if model == Page:
             model.move = _new_move
+        if issubclass(model, Page):
+            #model.move = _new_move
             model.set_url_path = _new_set_url_path
             model.route = _new_route
             model.get_site_root_paths = _new_get_site_root_paths


### PR DESCRIPTION
I think wagtailmodeltranslation should patch Page.move and not the specific Page inherit model.

For example if you have a BlogPage that defines a move method, the wagtailmodeltranslation's patch will break things (the custom move method will be never called because of the redefinition).

Maybe it's not so common to define a custom method like move, but it may happen. See torchbox/wagtail#2728

This patch is to avoid a custom defined method already existing in Page is overriden.

I also think that the way wagtail modeltranslation patches other methods like move should be reviews like this one.