### PR TITLE
Rm monkeypatching

### DIFF
--- a/wagtail_modeltranslation/patch_wagtailadmin.py
+++ b/wagtail_modeltranslation/patch_wagtailadmin.py
@@ -100,7 +100,6 @@ class WagtailTranslator(object):
         if issubclass(model, Page):
             model.move = _new_move
             model.set_url_path = _new_set_url_path
-            model.relative_url = _new_relative_url
             model.url = _new_url
             _patch_clean(model)
             _patch_elasticsearch_fields(model)
@@ -386,21 +385,6 @@ def _new_set_url_path(self, parent):
         child.set_url_path(self.specific)
 
     return self.url_path
-
-
-def _new_relative_url(self, current_site):
-    """
-    Return the 'most appropriate' URL for this page taking into account the site we're currently on;
-    a local URL if the site matches, or a fully qualified one otherwise.
-    Return None if the page is not routable.
-
-    Override for using custom get_site_root_paths() instead of
-    Site.get_site_root_paths()
-    """
-    for (id, root_path, root_url) in self.get_site_root_paths():
-        if self.url_path.startswith(root_path):
-            return ('' if current_site.id == id else root_url) + reverse('wagtail_serve',
-                                                                         args=(self.url_path[len(root_path):],))
 
 
 @property

--- a/wagtail_modeltranslation/patch_wagtailadmin.py
+++ b/wagtail_modeltranslation/patch_wagtailadmin.py
@@ -100,7 +100,6 @@ class WagtailTranslator(object):
         if issubclass(model, Page):
             model.move = _new_move
             model.set_url_path = _new_set_url_path
-            model.get_site_root_paths = _new_get_site_root_paths
             model.relative_url = _new_relative_url
             model.url = _new_url
             _patch_clean(model)
@@ -387,25 +386,6 @@ def _new_set_url_path(self, parent):
         child.set_url_path(self.specific)
 
     return self.url_path
-
-
-@staticmethod
-def _new_get_site_root_paths():
-    """
-    Return a list of (root_path, root_url) tuples, most specific path first -
-    used to translate url_paths into actual URLs with hostnames
-
-    Same method as Site.get_site_root_paths() but without cache
-
-    TODO: remake this method with cache and think of his integration in
-    Site.get_site_root_paths()
-    """
-    result = [
-        (site.id, site.root_page.specific.url_path, site.root_url)
-        for site in Site.objects.select_related('root_page').order_by('-root_page__url_path')
-        ]
-
-    return result
 
 
 def _new_relative_url(self, current_site):

--- a/wagtail_modeltranslation/patch_wagtailadmin.py
+++ b/wagtail_modeltranslation/patch_wagtailadmin.py
@@ -100,7 +100,6 @@ class WagtailTranslator(object):
         if issubclass(model, Page):
             model.move = _new_move
             model.set_url_path = _new_set_url_path
-            model.route = _new_route
             model.get_site_root_paths = _new_get_site_root_paths
             model.relative_url = _new_relative_url
             model.url = _new_url
@@ -388,41 +387,6 @@ def _new_set_url_path(self, parent):
         child.set_url_path(self.specific)
 
     return self.url_path
-
-
-def _new_route(self, request, path_components):
-    """
-    Rewrite route method in order to handle languages fallbacks
-    """
-    if path_components:
-        # request is for a child of this page
-        child_slug = path_components[0]
-        remaining_components = path_components[1:]
-
-        # try:
-        #     q = Q()
-        #     for lang in settings.LANGUAGES:
-        #         tr_field_name = 'slug_%s' % (lang[0])
-        #         condition = {tr_field_name: child_slug}
-        #         q |= Q(**condition)
-        #     subpage = self.get_children().get(q)
-        # except Page.DoesNotExist:
-        #     raise Http404
-
-        # return subpage.specific.route(request, remaining_components)
-
-        subpages = self.get_children()
-        for page in subpages:
-            if page.specific.slug == child_slug:
-                return page.specific.route(request, remaining_components)
-        raise Http404
-
-    else:
-        # request is for this very page
-        if self.live:
-            return RouteResult(self)
-        else:
-            raise Http404
 
 
 @staticmethod

--- a/wagtail_modeltranslation/patch_wagtailadmin.py
+++ b/wagtail_modeltranslation/patch_wagtailadmin.py
@@ -100,7 +100,6 @@ class WagtailTranslator(object):
         if issubclass(model, Page):
             model.move = _new_move
             model.set_url_path = _new_set_url_path
-            model.url = _new_url
             _patch_clean(model)
             _patch_elasticsearch_fields(model)
 
@@ -385,27 +384,6 @@ def _new_set_url_path(self, parent):
         child.set_url_path(self.specific)
 
     return self.url_path
-
-
-@property
-def _new_url(self):
-    """
-    Return the 'most appropriate' URL for referring to this page from the pages we serve,
-    within the Wagtail backend and actual website templates;
-    this is the local URL (starting with '/') if we're only running a single site
-    (i.e. we know that whatever the current page is being served from, this link will be on the
-    same domain), and the full URL (with domain) if not.
-    Return None if the page is not routable.
-
-    Override for using custom get_site_root_paths() instead of
-    Site.get_site_root_paths()
-    """
-    root_paths = self.get_site_root_paths()
-
-    for (id, root_path, root_url) in root_paths:
-        if self.url_path.startswith(root_path):
-            return ('' if len(root_paths) == 1 else root_url) + reverse(
-                'wagtail_serve', args=(self.url_path[len(root_path):],))
 
 
 def _validate_slugs(page):


### PR DESCRIPTION
Supersedes #93 

I think `_new_set_url_path` doesn't get in the way of custom `get_url_parts` and is where the logic of customized slugs is buried. So this monkey patch has be kept for now :)

I didn't spot any translation logic in the removed monkeypatches - so please help me understand if I'm doing anything wrong here.