### PR TITLE
Fix language copy buttons of streamfields

### DIFF
--- a/wagtail_modeltranslation/static/modeltranslation/js/copy_stream_fields.js
+++ b/wagtail_modeltranslation/static/modeltranslation/js/copy_stream_fields.js
@@ -11,15 +11,18 @@ $(document).ready(function(){
 		var header = $(currentStreamField).children('h2')[0];
 		//Search for the input field so that we can get is id to know the field's name.
 		var streamFieldDiv = $(currentStreamField).find('div.sequence-container.sequence-type-stream')[0];
-		var fieldInfos = $(streamFieldDiv).children('input')[0].id.split('-')[0];
-    var lastUnderscore = fieldInfos.lastIndexOf("_");
-    var fieldName = fieldInfos.substring(0, lastUnderscore);
-    var fieldLang = fieldInfos.substring(lastUnderscore + 1, fieldInfos.length);
+		var fieldId = $(streamFieldDiv).children('input')[0].id;
+		var fieldInfos = fieldId.split('-')[0];
+		var fieldIdPostfix = "-" + fieldId.split('-').slice(1).join("-");
+		var lastUnderscore = fieldInfos.lastIndexOf("_");
+	    var fieldName = fieldInfos.substring(0, lastUnderscore);
+	    var fieldLang = fieldInfos.substring(lastUnderscore + 1, fieldInfos.length);
+    
 		//The cycle to create the buttons for copy each language field
 		var copyContentString = 'Copy content from';
 		header.innerHTML += '<div class="translation-field-copy-wrapper">'+copyContentString+': </div>';
 		for (var j = 0; j < langs.length; j++) {
-			if (fieldLang != langs[j]) {
+			if ($("#" + fieldName + "_" + langs[j] + fieldIdPostfix).length && fieldLang != langs[j]) {
 				var currentFieldID = fieldName + '_' + fieldLang;
 				var targetFieldID = fieldName + '_' + langs [j];
 				$(header).children('.translation-field-copy-wrapper')[0].innerHTML += '<button class="translation-field-copy" current-lang-code="'+ currentFieldID +'" data-lang-code="'+ targetFieldID +'">'+langs[j]+'</button>';

--- a/wagtail_modeltranslation/static/modeltranslation/js/copy_stream_fields.js
+++ b/wagtail_modeltranslation/static/modeltranslation/js/copy_stream_fields.js
@@ -1,7 +1,9 @@
 /* Creates the copy buttons in the header of each stream field */
-$(document).ready(function(){
+
+init_copy_stream_fields = function(){
 	//All the stream fields with all his content
-	var allStreamFields = $('li.stream-field');
+	var allStreamFields = $('li.stream-field:not([initialized])');
+	allStreamFields.attr("initialized", "1");
 
 	/* Iterate all stream fields, put the copy buttons in each one.*/
 	for (var i = 0; i < allStreamFields.length; i++) {
@@ -50,7 +52,7 @@ $(document).ready(function(){
 	};
 
 	/* on click binding */
-	$('.translation-field-copy').click(function(event){
+	allStreamFields.find('.translation-field-copy').click(function(event){
 		event.preventDefault();
 		var lang = $(this).attr('data-lang-code');
 		var currentLang = $(this).attr('current-lang-code');
@@ -58,6 +60,15 @@ $(document).ready(function(){
 		var relatedModelOffset = $(this).attr('related-model-offset');
 		requestCopyField(lang, currentLang, relatedModel, relatedModelOffset);
 	});
+	
+	/* Initialize new elements inside InlinePanel added by the user */
+	allStreamFields.parents("ul.multiple").siblings("p.add").click(function(){
+		window.setTimeout(init_copy_stream_fields, 500);
+	});
+}
+
+$(document).ready(function(){
+	init_copy_stream_fields();
 });
 
 /* Copy the content of originID field to the targetID field */

--- a/wagtail_modeltranslation/static/modeltranslation/js/copy_stream_fields.js
+++ b/wagtail_modeltranslation/static/modeltranslation/js/copy_stream_fields.js
@@ -5,17 +5,34 @@ $(document).ready(function(){
 
 	/* Iterate all stream fields, put the copy buttons in each one.*/
 	for (var i = 0; i < allStreamFields.length; i++) {
+		var is_streamfield_in_inlinepanel = false;
 		//Current Field with all content
 		var currentStreamField = allStreamFields[i];
 		//Current Field header
 		var header = $(currentStreamField).children('h2')[0];
-		if (!header) //True if StreamField inside InlinePanel
-			continue;
+		if (!header) { //True if StreamField inside InlinePanel
+			is_streamfield_in_inlinepanel = true;
+			var header = $(currentStreamField).find('label:first')[0];
+		}
 		//Search for the input field so that we can get is id to know the field's name.
 		var streamFieldDiv = $(currentStreamField).find('div.sequence-container.sequence-type-stream')[0];
 		var fieldId = $(streamFieldDiv).children('input')[0].id;
-		var fieldInfos = fieldId.split('-')[0];
-		var fieldIdPostfix = "-" + fieldId.split('-').slice(1).join("-");
+		
+		if (is_streamfield_in_inlinepanel) {
+			var relatedModel = fieldId.split('-')[0];
+			var relatedModelOffset = fieldId.split('-')[1];
+			var fieldIdPrefix = fieldId.split('-').slice(0,2).join("-") + "-";
+			var fieldInfos = fieldId.split('-').slice(2,3).join("-");
+			var fieldIdPostfix = "-" + fieldId.split('-').slice(3).join("-");
+		}
+		else {
+			var relatedModel = '';
+			var relatedModelOffset = '';
+			var fieldIdPrefix = "";
+			var fieldInfos = fieldId.split('-')[0];
+			var fieldIdPostfix = "-" + fieldId.split('-').slice(1).join("-");
+		}
+		
 		var lastUnderscore = fieldInfos.lastIndexOf("_");
 	    var fieldName = fieldInfos.substring(0, lastUnderscore);
 	    var fieldLang = fieldInfos.substring(lastUnderscore + 1, fieldInfos.length);
@@ -24,10 +41,10 @@ $(document).ready(function(){
 		var copyContentString = 'Copy content from';
 		header.innerHTML += '<div class="translation-field-copy-wrapper">'+copyContentString+': </div>';
 		for (var j = 0; j < langs.length; j++) {
-			if ($("#" + fieldName + "_" + langs[j] + fieldIdPostfix).length && fieldLang != langs[j]) {
+			if ($("#" + fieldIdPrefix + fieldName + "_" + langs[j] + fieldIdPostfix).length && fieldLang != langs[j]) {
 				var currentFieldID = fieldName + '_' + fieldLang;
 				var targetFieldID = fieldName + '_' + langs [j];
-				$(header).children('.translation-field-copy-wrapper')[0].innerHTML += '<button class="translation-field-copy" current-lang-code="'+ currentFieldID +'" data-lang-code="'+ targetFieldID +'">'+langs[j]+'</button>';
+				$(header).children('.translation-field-copy-wrapper')[0].innerHTML += '<button class="translation-field-copy" current-lang-code="'+ currentFieldID +'" data-lang-code="'+ targetFieldID +'" related-model="' + relatedModel + '" related-model-offset="' + relatedModelOffset + '">'+langs[j]+'</button>';
 			};
 		};
 	};
@@ -37,17 +54,22 @@ $(document).ready(function(){
 		event.preventDefault();
 		var lang = $(this).attr('data-lang-code');
 		var currentLang = $(this).attr('current-lang-code');
-		requestCopyField(lang, currentLang);
+		var relatedModel = $(this).attr('related-model');
+		var relatedModelOffset = $(this).attr('related-model-offset');
+		requestCopyField(lang, currentLang, relatedModel, relatedModelOffset);
 	});
 });
 
 /* Copy the content of originID field to the targetID field */
-function requestCopyField(originID, targetID) {
+function requestCopyField(originID, targetID, relatedModel, relatedModelOffset) {
 	/* Get the originID field and convert him to json string */
 	var serializedForm = $("#page-edit-form").serializeArray();
-	var serializedOriginField = $.grep(serializedForm, function(obj){return obj.name.indexOf(originID) >= 0;});
+	var serializedOriginField = $.grep(serializedForm, function(obj){
+		if (relatedModel)
+			return obj.name.indexOf(relatedModel + "-" + relatedModelOffset + "-" + originID) >= 0;
+		return obj.name.indexOf(originID) >= 0;
+	});
 	var jsonString = JSON.stringify(serializedOriginField);
-
 	/*
 	 * AJAX request that returns the html content of originID field
 	 * with the id's changed to targetID
@@ -56,11 +78,14 @@ function requestCopyField(originID, targetID) {
 		url: 'copy_translation_content',
 		type: 'POST',
 		dataType: 'json',
-		data: {'origin_field_name': originID, 'target_field_name': targetID, 'serializedOriginField': jsonString},
+		data: {'origin_field_name': originID, 'target_field_name': targetID, 'related_model': relatedModel, 'related_model_offset': relatedModelOffset, 'serializedOriginField': jsonString},
 	})
 	.done(function(data) {
 		/* Put the html data in the targetID field */
-		var wrapperDiv = $("#"+targetID+"-count").parents('.input')[0];
+		var target = targetID;
+		if (relatedModel)
+			target = relatedModel + "-" + relatedModelOffset + "-" + targetID;
+		var wrapperDiv = $("#"+target+"-count").parents('.input')[0];
 		$(wrapperDiv).html(data);
 	})
 	.fail(function(error) {

--- a/wagtail_modeltranslation/static/modeltranslation/js/copy_stream_fields.js
+++ b/wagtail_modeltranslation/static/modeltranslation/js/copy_stream_fields.js
@@ -61,14 +61,22 @@ init_copy_stream_fields = function(){
 		requestCopyField(lang, currentLang, relatedModel, relatedModelOffset);
 	});
 	
-	/* Initialize new elements inside InlinePanel added by the user */
-	allStreamFields.parents("ul.multiple").siblings("p.add").click(function(){
-		window.setTimeout(init_copy_stream_fields, 500);
-	});
+	if (copy_stream_fields_is_first_init) {
+		/* Initialize new elements inside InlinePanel added by the user */
+		allStreamFields.parents("ul.multiple").siblings("p.add").click(init_added_copy_stream_fields);
+		/* Initialize empty InlinePanel that may contain StreamField */
+		$("li.object.empty p.add").click(init_added_copy_stream_fields);
+	}
 }
 
+init_added_copy_stream_fields = function(){
+	window.setTimeout(init_copy_stream_fields, 500);
+}
+
+var copy_stream_fields_is_first_init = true;
 $(document).ready(function(){
 	init_copy_stream_fields();
+	copy_stream_fields_is_first_init = false;
 });
 
 /* Copy the content of originID field to the targetID field */

--- a/wagtail_modeltranslation/static/modeltranslation/js/copy_stream_fields.js
+++ b/wagtail_modeltranslation/static/modeltranslation/js/copy_stream_fields.js
@@ -9,6 +9,8 @@ $(document).ready(function(){
 		var currentStreamField = allStreamFields[i];
 		//Current Field header
 		var header = $(currentStreamField).children('h2')[0];
+		if (!header) //True if StreamField inside InlinePanel
+			continue;
 		//Search for the input field so that we can get is id to know the field's name.
 		var streamFieldDiv = $(currentStreamField).find('div.sequence-container.sequence-type-stream')[0];
 		var fieldId = $(streamFieldDiv).children('input')[0].id;

--- a/wagtail_modeltranslation/wagtail_hooks.py
+++ b/wagtail_modeltranslation/wagtail_hooks.py
@@ -74,7 +74,7 @@ def return_translation_target_field_rendered_html(request, page_id):
         # get render html
 
         if related_model :
-            target_field = getattr(page.specific, related_model).all()[related_model_offset]._meta.get_field(target_field_name)
+            target_field = getattr(page.specific, related_model).model._meta.get_field(target_field_name)
             q_data_target_field_name = "%s-%s-%s" % (related_model, related_model_offset, target_field_name)
         else :
             target_field = page.specific._meta.get_field(target_field_name)


### PR DESCRIPTION
Streamfields always show the language buttons to copy the content from other streamfields, but not all streamfields may be marked as being multilanguage.

This modification checks for the existance of the other streamfields of same type before rendering the language buttons. Only multilanguage streamfields are found.
