### PR TITLE
Fix issue #7 (error copying pages)

### DIFF
--- a/wagtail_modeltranslation/patch_wagtailadmin.py
+++ b/wagtail_modeltranslation/patch_wagtailadmin.py
@@ -529,7 +529,7 @@ def _validate_slugs(page, parent_page=None, slugs_to_check=None, exclude_self=Tr
     allowed_sibblings = parent_page.specific.allowed_subpage_models()
     siblings = parent_page.get_children()
     if exclude_self :
-        siblings.exclude(pk=page.pk)
+        siblings = siblings.exclude(pk=page.pk)
 
     errors = {}
 

--- a/wagtail_modeltranslation/patch_wagtailadmin.py
+++ b/wagtail_modeltranslation/patch_wagtailadmin.py
@@ -2,6 +2,7 @@
 import copy
 import logging
 import operator
+import inspect
 
 from django.conf import settings
 from django.core.exceptions import ValidationError
@@ -28,6 +29,8 @@ try:
 except ImportError:
     pass
 
+from wagtail_modeltranslation.patch_wagtailadmin_forms import WagtailModeltranslationAdminPageForm
+
 logger = logging.getLogger('wagtail.core')
 
 
@@ -43,6 +46,9 @@ class WagtailTranslator(object):
         WagtailTranslator._base_model = model
         WagtailTranslator._required_fields = {}
 
+        if issubclass(model, Page):
+            model.base_form_class = WagtailModeltranslationAdminPageForm  # This must be before the next edit_handler_class patch
+
         # CONSTRUCT TEMPORARY EDIT HANDLER
         if issubclass(model, Page):
             if hasattr(model, 'get_edit_handler'):
@@ -55,7 +61,9 @@ class WagtailTranslator(object):
 
         defined_tabs = WagtailTranslator._fetch_defined_tabs(model)
 
+        k = -1
         for tab_name, tab in defined_tabs:
+            k += 1
             patched_tab = []
 
             for panel in tab:
@@ -66,6 +74,9 @@ class WagtailTranslator(object):
                         patched_tab.append(x)
 
             setattr(model, tab_name, patched_tab)
+            
+            if hasattr(model, 'edit_handler') :
+                model.edit_handler.children[k].children = patched_tab
 
         # DELETE TEMPORARY EDIT HANDLER IN ORDER TO LET WAGTAIL RECONSTRUCT
         # NEW EDIT HANDLER BASED ON NEW TRANSLATION PANELS
@@ -122,12 +133,33 @@ class WagtailTranslator(object):
             tabs += (('panels', copy.deepcopy(defined_class.panels)),)
         # Check for common tabs
         else:
-            if hasattr(defined_class, 'content_panels'):
-                tabs += (('content_panels', copy.deepcopy(defined_class.content_panels)),)
-            if hasattr(defined_class, 'promote_panels'):
-                tabs += (('promote_panels', copy.deepcopy(defined_class.promote_panels)),)
-            if hasattr(defined_class, 'settings_panels'):
-                tabs += (('settings_panels', copy.deepcopy(defined_class.settings_panels)),)
+            
+            if hasattr(defined_class, 'edit_handler') :
+                
+                #Find all class members that could be tab panels like content_panels, settings_panels, promote_panels and any other custom defined panels
+                tab_panels = inspect.getmembers(defined_class, lambda x : isinstance(x, list))
+                
+                k = -1
+                for objlist in defined_class.edit_handler.children:
+                    k += 1
+                    
+                    #Try to understand if this tab_panel was defined as model attribute, so we can recycle its name and update its value
+                    for tab_panel_name, tab_panel in tab_panels :
+                        if tab_panel == objlist.children :
+                            tab_name = tab_panel_name
+                            break
+                    else :
+                        #It happens if a custom tab panel is defined as list onto the edit_handler directly
+                        tab_name = 'tab_panels_%d' % k
+                        
+                    tabs += ((tab_name, copy.deepcopy(objlist.children)),)
+            else :
+                if hasattr(defined_class, 'content_panels'):
+                    tabs += (('content_panels', copy.deepcopy(defined_class.content_panels)),)
+                if hasattr(defined_class, 'promote_panels'):
+                    tabs += (('promote_panels', copy.deepcopy(defined_class.promote_panels)),)
+                if hasattr(defined_class, 'settings_panels'):
+                    tabs += (('settings_panels', copy.deepcopy(defined_class.settings_panels)),)
 
         return tabs
 
@@ -480,19 +512,24 @@ def _new_url(self):
                 'wagtail_serve', args=(self.url_path[len(root_path):],))
 
 
-def _validate_slugs(page):
+def _validate_slugs(page, parent_page=None, slugs_to_check=None, exclude_self=True):
     """
     Determine whether the given slug is available for use on a child page of
     parent_page.
+
+    slugs_to_check: if used it must be a dict object where the keys are the translated slug fields and the values are what have to be checked
+        To be used if you want check specific values instead of the page's current slug values
     """
-    parent_page = page.get_parent()
+    parent_page = page.get_parent() if parent_page is None else parent_page
 
     if parent_page is None:
         # the root page's slug can be whatever it likes...
         return {}
 
     allowed_sibblings = parent_page.specific.allowed_subpage_models()
-    siblings = parent_page.get_children().exclude(pk=page.pk)
+    siblings = parent_page.get_children()
+    if exclude_self :
+        siblings.exclude(pk=page.pk)
 
     errors = {}
 
@@ -501,7 +538,7 @@ def _validate_slugs(page):
         query_list = []
 
         for model in allowed_sibblings:
-            slug = getattr(page, current_slug, '') or ''
+            slug = slugs_to_check[current_slug] if slugs_to_check is not None else getattr(page, current_slug, '') or ''
             if len(slug) and model is not Page:
                 if model in WagtailTranslator._patched_models:
                     field_name = '{0}__{1}'.format(model._meta.model_name, current_slug)
@@ -539,4 +576,4 @@ def _patch_elasticsearch_fields(model):
             for lang in settings.LANGUAGES:
                 translated_field = copy.deepcopy(field)
                 translated_field.field_name = build_localized_fieldname(field.field_name, lang[0])
-                model.search_fields = model.search_fields + (translated_field,)
+                model.search_fields = list(model.search_fields) + [translated_field]

--- a/wagtail_modeltranslation/patch_wagtailadmin_forms.py
+++ b/wagtail_modeltranslation/patch_wagtailadmin_forms.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+
+from django.conf import settings
+
+from django import forms
+from django.utils.translation import ugettext as _
+
+from wagtail.wagtailadmin import widgets
+from wagtail.wagtailadmin.forms import CopyForm
+from wagtail.wagtailcore.models import Page
+
+# Copied from wagtail.wagtailadmin.forms.CopyForm and modified
+class NewCopyForm(CopyForm):
+    def __init__(self, *args, **kwargs):
+        # CopyPage must be passed a 'page' kwarg indicating the page to be copied
+        self.page = kwargs.pop('page').specific
+        can_publish = kwargs.pop('can_publish')
+        super(CopyForm, self).__init__(*args, **kwargs)
+
+        self.fields['new_title'] = forms.CharField(initial=self.page.title, label=_("New title"))
+        for isocode, description in settings.LANGUAGES:
+            self.fields['new_title_%s' % isocode] = forms.CharField(initial=getattr(self.page, "title_%s" % isocode), label=_("New title") + (" [%s]" % isocode))
+            
+        self.fields['new_slug'] = forms.SlugField(initial=self.page.slug, label=_("New slug"))
+        for isocode, description in settings.LANGUAGES:
+            self.fields['new_slug_%s' % isocode] = forms.CharField(initial=getattr(self.page, "slug_%s" % isocode), label=_("New slug") + (" [%s]" % isocode))
+            
+        self.fields['new_parent_page'] = forms.ModelChoiceField(
+            initial=self.page.get_parent(),
+            queryset=Page.objects.all(),
+            widget=widgets.AdminPageChooser(can_choose_root=True),
+            label=_("New parent page"),
+            help_text=_("This copy will be a child of this given parent page.")
+        )
+
+        pages_to_copy = self.page.get_descendants(inclusive=True)
+        subpage_count = pages_to_copy.count() - 1
+        if subpage_count > 0:
+            self.fields['copy_subpages'] = forms.BooleanField(
+                required=False, initial=True, label=_("Copy subpages"),
+                help_text=ungettext(
+                    "This will copy %(count)s subpage.",
+                    "This will copy %(count)s subpages.",
+                    subpage_count) % {'count': subpage_count})
+
+        if can_publish:
+            pages_to_publish_count = pages_to_copy.live().count()
+            if pages_to_publish_count > 0:
+                # In the specific case that there are no subpages, customise the field label and help text
+                if subpage_count == 0:
+                    label = _("Publish copied page")
+                    help_text = _("This page is live. Would you like to publish its copy as well?")
+                else:
+                    label = _("Publish copies")
+                    help_text = ungettext(
+                        "%(count)s of the pages being copied is live. Would you like to publish its copy?",
+                        "%(count)s of the pages being copied are live. Would you like to publish their copies?",
+                        pages_to_publish_count) % {'count': pages_to_publish_count}
+
+                self.fields['publish_copies'] = forms.BooleanField(
+                    required=False, initial=True, label=label, help_text=help_text
+                )

--- a/wagtail_modeltranslation/patch_wagtailadmin_views.py
+++ b/wagtail_modeltranslation/patch_wagtailadmin_views.py
@@ -12,7 +12,11 @@ from wagtail.wagtailadmin.views.pages import get_valid_next_url_from_request
 
 from wagtail_modeltranslation.patch_wagtailadmin_forms import NewCopyForm
 
-# Copied from wagtail.wagtailadmin.views.pages.copy and modified
+
+# Copied from wagtail.wagtailadmin.views.pages.copy for these modifications
+# - change data in update_attrs dict (use language fields instead of the original ones)
+# - add settings.LANGUAGES to the template context
+# - make use of the NewCopyForm (patch of the original CopyForm)
 def new_copy(request, page_id):
     page = Page.objects.get(id=page_id)
 
@@ -45,15 +49,11 @@ def new_copy(request, page_id):
             # Re-check if the user has permission to publish subpages on the new parent
             can_publish = parent_page.permissions_for_user(request.user).can_publish_subpage()
 
-            update_attrs = {
-                'title': form.cleaned_data['new_title'],
-                'slug': form.cleaned_data['new_slug'],
-            }
-            
+            update_attrs = {}
             for isocode, description in settings.LANGUAGES:
                 for fieldname in ['title', 'slug']:
                     update_attrs['%s_%s' % (fieldname, isocode)] = form.cleaned_data['new_%s_%s' % (fieldname, isocode)]
-                    
+
             # Copy the page
             new_page = page.copy(
                 recursive=form.cleaned_data.get('copy_subpages'),

--- a/wagtail_modeltranslation/patch_wagtailadmin_views.py
+++ b/wagtail_modeltranslation/patch_wagtailadmin_views.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+
+from django.conf import settings
+
+from django.core.exceptions import PermissionDenied
+from django.shortcuts import redirect, render
+from django.utils.translation import ugettext as _
+
+from wagtail.wagtailcore.models import Page
+from wagtail.wagtailadmin import messages
+from wagtail.wagtailadmin.views.pages import get_valid_next_url_from_request
+
+from wagtail_modeltranslation.patch_wagtailadmin_forms import NewCopyForm
+
+# Copied from wagtail.wagtailadmin.views.pages.copy and modified
+def new_copy(request, page_id):
+    page = Page.objects.get(id=page_id)
+
+    # Parent page defaults to parent of source page
+    parent_page = page.get_parent()
+
+    # Check if the user has permission to publish subpages on the parent
+    can_publish = parent_page.permissions_for_user(request.user).can_publish_subpage()
+
+    # Create the form
+    form = NewCopyForm(request.POST or None, page=page, can_publish=can_publish)
+
+    next_url = get_valid_next_url_from_request(request)
+
+    # Check if user is submitting
+    if request.method == 'POST':
+        # Prefill parent_page in case the form is invalid (as prepopulated value for the form field,
+        # because ModelChoiceField seems to not fall back to the user given value)
+        parent_page = Page.objects.get(id=request.POST['new_parent_page'])
+
+        if form.is_valid():
+            # Receive the parent page (this should never be empty)
+            if form.cleaned_data['new_parent_page']:
+                parent_page = form.cleaned_data['new_parent_page']
+
+            # Make sure this user has permission to add subpages on the parent
+            if not parent_page.permissions_for_user(request.user).can_add_subpage():
+                raise PermissionDenied
+
+            # Re-check if the user has permission to publish subpages on the new parent
+            can_publish = parent_page.permissions_for_user(request.user).can_publish_subpage()
+
+            update_attrs = {
+                'title': form.cleaned_data['new_title'],
+                'slug': form.cleaned_data['new_slug'],
+            }
+            
+            for isocode, description in settings.LANGUAGES:
+                for fieldname in ['title', 'slug']:
+                    update_attrs['%s_%s' % (fieldname, isocode)] = form.cleaned_data['new_%s_%s' % (fieldname, isocode)]
+                    
+            # Copy the page
+            new_page = page.copy(
+                recursive=form.cleaned_data.get('copy_subpages'),
+                to=parent_page,
+                update_attrs=update_attrs,
+                keep_live=(can_publish and form.cleaned_data.get('publish_copies')),
+                user=request.user,
+            )
+
+            # Give a success message back to the user
+            if form.cleaned_data.get('copy_subpages'):
+                messages.success(
+                    request,
+                    _("Page '{0}' and {1} subpages copied.").format(page.title, new_page.get_descendants().count())
+                )
+            else:
+                messages.success(request, _("Page '{0}' copied.").format(page.title))
+
+            # Redirect to explore of parent page
+            if next_url:
+                return redirect(next_url)
+            return redirect('wagtailadmin_explore', parent_page.id)
+
+    return render(request, 'wagtailadmin/pages/copy.html', {
+        'LANGUAGES': settings.LANGUAGES,
+        'page': page,
+        'form': form,
+        'next': next_url,
+    })

--- a/wagtail_modeltranslation/templates/wagtailadmin/pages/copy.html
+++ b/wagtail_modeltranslation/templates/wagtailadmin/pages/copy.html
@@ -1,0 +1,39 @@
+{% extends "wagtailadmin/base.html" %}
+{% load i18n %}
+{% block titletag %}{% blocktrans with title=page.title %}Copy {{ title }}{% endblocktrans %}{% endblock %}
+{% block content %}
+    {% trans "Copy" as copy_str %}
+    {% include "wagtailadmin/shared/header.html" with title=copy_str subtitle=page.title icon="doc-empty-inverse" %}
+
+    <div class="nice-padding">
+        <form action="{% url 'wagtailadmin_pages:copy' page.id %}" method="POST" novalidate>
+            {% csrf_token %}
+            <input type="hidden" name="next" value="{{ next }}" />
+
+            <ul class="fields">
+            	{% include "wagtailadmin/shared/field_as_li.html" with field=form.new_title %}
+            	{% include "wagtailadmin/shared/field_as_li.html" with field=form.new_title_it %}
+            	{% include "wagtailadmin/shared/field_as_li.html" with field=form.new_title_en %}
+            	{% include "wagtailadmin/shared/field_as_li.html" with field=form.new_slug %}
+                {% include "wagtailadmin/shared/field_as_li.html" with field=form.new_slug_it %}
+                {% include "wagtailadmin/shared/field_as_li.html" with field=form.new_slug_en %}
+                {% include "wagtailadmin/shared/field_as_li.html" with field=form.new_parent_page %}
+
+                {% if form.copy_subpages %}
+                    {% include "wagtailadmin/shared/field_as_li.html" with field=form.copy_subpages %}
+                {% endif %}
+
+                {% if form.publish_copies %}
+                    {% include "wagtailadmin/shared/field_as_li.html" with field=form.publish_copies %}
+                {% endif %}
+            </ul>
+
+            <input type="submit" value="{% trans 'Copy this page' %}" class="button">
+        </form>
+    </div>
+{% endblock %}
+
+{% block extra_js %}
+    {{ block.super }}
+    {% include "wagtailadmin/pages/_editor_js.html" %}
+{% endblock %}

--- a/wagtail_modeltranslation/templates/wagtailadmin/pages/copy.html
+++ b/wagtail_modeltranslation/templates/wagtailadmin/pages/copy.html
@@ -11,12 +11,16 @@
             <input type="hidden" name="next" value="{{ next }}" />
 
             <ul class="fields">
-            	{% include "wagtailadmin/shared/field_as_li.html" with field=form.new_title %}
-            	{% include "wagtailadmin/shared/field_as_li.html" with field=form.new_title_it %}
-            	{% include "wagtailadmin/shared/field_as_li.html" with field=form.new_title_en %}
-            	{% include "wagtailadmin/shared/field_as_li.html" with field=form.new_slug %}
-                {% include "wagtailadmin/shared/field_as_li.html" with field=form.new_slug_it %}
-                {% include "wagtailadmin/shared/field_as_li.html" with field=form.new_slug_en %}
+            	{% for field in form.visible_fields %}
+            		{% if field.name|make_list|slice:":9"|join:"" == "new_title" %}
+            			{% include "wagtailadmin/shared/field_as_li.html" with field=field %}
+            		{% endif %}
+            	{% endfor %}
+            	{% for field in form.visible_fields %}
+            		{% if field.name|make_list|slice:":8"|join:"" == "new_slug" %}
+            			{% include "wagtailadmin/shared/field_as_li.html" with field=field %}
+            		{% endif %}
+            	{% endfor %}
                 {% include "wagtailadmin/shared/field_as_li.html" with field=form.new_parent_page %}
 
                 {% if form.copy_subpages %}

--- a/wagtail_modeltranslation/translator.py
+++ b/wagtail_modeltranslation/translator.py
@@ -69,16 +69,19 @@ class TranslationOptions(with_metaclass(FieldsAggregationMetaClass, object)):
         """
         Create fields dicts without any translation fields.
         """
+        
         page_fields = ()
-
+        
+        self.page_fields = (
+            'title',
+            'slug',
+            'seo_title',
+            'search_description',
+            'url_path',)
+        
         if Page in model.__bases__:
-            page_fields = (
-                'title',
-                'slug',
-                'seo_title',
-                'search_description',
-                'url_path',)
-
+            page_fields = self.page_fields
+        
         self.model = model
         self.registered = False
         self.related = False
@@ -98,7 +101,8 @@ class TranslationOptions(with_metaclass(FieldsAggregationMetaClass, object)):
             else:
                 self._check_languages(self.required_languages.keys(), extra=('default',))
                 for fieldnames in self.required_languages.values():
-                    if any(f not in self.fields for f in fieldnames):
+                    checkfields = self.page_fields if self.model == Page else self.fields
+                    if any(f not in checkfields for f in fieldnames):
                         raise ImproperlyConfigured(
                             'Fieldname in required_languages which is not in fields option.')
 

--- a/wagtail_modeltranslation/urls.py
+++ b/wagtail_modeltranslation/urls.py
@@ -6,6 +6,6 @@ from wagtail.wagtailadmin import urls as wagtailadmin_urls
 from wagtail_modeltranslation.patch_wagtailadmin_views import new_copy
 
 urlpatterns = [
-    url(r'^pages/(\d+)/copy/$', new_copy, name = 'copy'),
+    url(r'^pages/(\d+)/copy/$', new_copy, name='copy'),
     url(r'^', include(wagtailadmin_urls)),
 ]

--- a/wagtail_modeltranslation/urls.py
+++ b/wagtail_modeltranslation/urls.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+from django.conf.urls import url, include
+
+from wagtail.wagtailadmin import urls as wagtailadmin_urls
+
+from wagtail_modeltranslation.patch_wagtailadmin_views import new_copy
+
+urlpatterns = [
+    url(r'^pages/(\d+)/copy/$', new_copy, name = 'copy'),
+    url(r'^', include(wagtailadmin_urls)),
+]


### PR DESCRIPTION
This fixes #7

Please note that I had to patch a wagtail view, this means wagtail_modeltranslation users have to do an important change to their main urls.py and the wagtail_modeltranslation guide should be change accordingly.

You do not have to import wagtailadmin_urls anymore, you have to import the new wagtail_modeltranslation_urls instead (that will import the wagtail's ones)

urls.py
```
#from wagtail.wagtailadmin import urls as wagtailadmin_urls
from wagtail_modeltranslation import urls as wagtail_modeltranslation_urls

urlpatterns = patterns('')

urlpatterns += patterns('',
    #url(r'^/admin/', include(wagtailadmin_urls)),
    url(r'^/admin/', include(wagtail_modeltranslation_urls)),
)
```