### PR TITLE
Fix Issue #98 - Check for duplicated slug

### DIFF
--- a/wagtail_modeltranslation/patch_wagtailadmin.py
+++ b/wagtail_modeltranslation/patch_wagtailadmin.py
@@ -566,4 +566,4 @@ def _patch_elasticsearch_fields(model):
             for lang in settings.LANGUAGES:
                 translated_field = copy.deepcopy(field)
                 translated_field.field_name = build_localized_fieldname(field.field_name, lang[0])
-                model.search_fields = model.search_fields + (translated_field,)
+                model.search_fields = model.search_fields + [translated_field,]

--- a/wagtail_modeltranslation/patch_wagtailadmin.py
+++ b/wagtail_modeltranslation/patch_wagtailadmin.py
@@ -574,4 +574,4 @@ def _patch_elasticsearch_fields(model):
             for lang in settings.LANGUAGES:
                 translated_field = copy.deepcopy(field)
                 translated_field.field_name = build_localized_fieldname(field.field_name, lang[0])
-                model.search_fields = model.search_fields + [translated_field]
+                model.search_fields = list(model.search_fields) + [translated_field]

--- a/wagtail_modeltranslation/patch_wagtailadmin_forms.py
+++ b/wagtail_modeltranslation/patch_wagtailadmin_forms.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+
+from django.conf import settings
+
+from django import forms
+
+from wagtail.wagtailadmin.forms import WagtailAdminPageForm
+
+
+class WagtailModeltranslationAdminPageForm(WagtailAdminPageForm):
+
+    def __init__(self, data=None, files=None, parent_page=None, *args, **kwargs):
+        super(WagtailModeltranslationAdminPageForm, self).__init__(data, files, parent_page, *args, **kwargs)
+
+    def clean(self):
+
+        cleaned_data = super(WagtailModeltranslationAdminPageForm, self).clean()
+
+        from wagtail_modeltranslation.patch_wagtailadmin import _validate_slugs
+
+        slugs_to_check = {}
+        for isocode, description in settings.LANGUAGES:
+            slugs_to_check["slug_%s" % isocode] = cleaned_data["slug_%s" % isocode]
+
+        for slugfield, des_error in _validate_slugs(self.instance,
+                                                    parent_page=self.parent_page,
+                                                    slugs_to_check=slugs_to_check).items():
+            self.add_error(slugfield, forms.ValidationError(des_error))
+
+        return cleaned_data

--- a/wagtail_modeltranslation/translator.py
+++ b/wagtail_modeltranslation/translator.py
@@ -69,16 +69,19 @@ class TranslationOptions(with_metaclass(FieldsAggregationMetaClass, object)):
         """
         Create fields dicts without any translation fields.
         """
+        
         page_fields = ()
-
+        
+        self.page_fields = (
+            'title',
+            'slug',
+            'seo_title',
+            'search_description',
+            'url_path',)
+        
         if Page in model.__bases__:
-            page_fields = (
-                'title',
-                'slug',
-                'seo_title',
-                'search_description',
-                'url_path',)
-
+            page_fields = self.page_fields
+        
         self.model = model
         self.registered = False
         self.related = False
@@ -98,7 +101,8 @@ class TranslationOptions(with_metaclass(FieldsAggregationMetaClass, object)):
             else:
                 self._check_languages(self.required_languages.keys(), extra=('default',))
                 for fieldnames in self.required_languages.values():
-                    if any(f not in self.fields for f in fieldnames):
+                    checkfields = self.page_fields if self.model == Page else self.fields
+                    if any(f not in checkfields for f in fieldnames):
                         raise ImproperlyConfigured(
                             'Fieldname in required_languages which is not in fields option.')
 


### PR DESCRIPTION
This PR fixes #98

Please note this PR depends on (and already includes) #86 and #87 and #90 (this just for the commit 2c10be35d3e38eae8053244a3e319e124690d276)

This PR patches the default Page.base_form_class (WagtailAdminPageForm): this means that if you need a custom form, your custom form must inherit from the new WagtailModeltranslationAdminPageForm instead of WagtailAdminPageForm.