### PR TITLE
Though rare and hard to reproduce it is possible for default_localize…

### DIFF
--- a/wagtail_modeltranslation/patch_wagtailadmin.py
+++ b/wagtail_modeltranslation/patch_wagtailadmin.py
@@ -336,6 +336,8 @@ def _new_url(self):
 
     for (id, root_path, root_url) in root_paths:
         if self.url_path.startswith(root_path):
+            if root_path == '':
+                root_path = '/'
             return ('' if len(root_paths) == 1 else root_url) + reverse(
                 'wagtail_serve', args=(self.url_path[len(root_path):],))
 

--- a/wagtail_modeltranslation/patch_wagtailadmin.py
+++ b/wagtail_modeltranslation/patch_wagtailadmin.py
@@ -240,9 +240,12 @@ def _new_set_url_path(self, parent):
             # Emulate the default behavior of django-modeltranslation to get the slug and url path
             # for the current language. If the value for the current language is invalid we get the one
             # for the default fallback language
-            slug = getattr(self, localized_slug_field, None) or getattr(self, default_localized_slug_field, self.slug)
-            parent_url_path = getattr(parent, localized_url_path_field, None) or \
-                              getattr(parent, default_localized_url_path_field, parent.url_path)
+            slug = getattr(self, localized_slug_field, None) or getattr(self, default_localized_slug_field, None) or self.slug
+            parent_url_path = (
+                getattr(parent, localized_url_path_field, None)
+                or getattr(parent, default_localized_url_path_field, None)
+                or parent.url_path
+            )
 
             setattr(self, localized_url_path_field, parent_url_path + slug + '/')
 


### PR DESCRIPTION
…d_slug_field be None, in that case, we try to add None to slug which causes an exception.

I believe these small codes changes are strictly better, but I don't have a good set of steps to reproduce. I was migrating my database back and forth as I was switching from a RichTextField to a StreamField and somehow got a Draft where self.default_localized_slug_field was None.