### PR TITLE
rename handle_noargs to handle in management commands

### DIFF
--- a/wagtail_modeltranslation/management/commands/set_translation_url_paths.py
+++ b/wagtail_modeltranslation/management/commands/set_translation_url_paths.py
@@ -30,7 +30,7 @@ class Command(BaseCommand):
 
             self.set_subtree(child, root_path + slug + '/', lang)
 
-    def handle_noargs(self, **options):
+    def handle(self, **options):
         for node in Page.get_root_nodes():
             for lang in settings.LANGUAGES:
                 self.set_subtree(node, '/', lang=lang[0])

--- a/wagtail_modeltranslation/management/commands/update_translation_fields.py
+++ b/wagtail_modeltranslation/management/commands/update_translation_fields.py
@@ -13,7 +13,7 @@ class Command(BaseCommand):
     help = ('Updates empty values of default translation fields using'
             ' values from original fields (in all translated models).')
 
-    def handle_noargs(self, **options):
+    def handle(self, **options):
         verbosity = int(options['verbosity'])
         if verbosity > 0:
             self.stdout.write(


### PR DESCRIPTION
BaseCommand expects `handle` and not `handle_noargs`