### PR TITLE
Remove extraneous .children reference

### DIFF
--- a/wagtail_modeltranslation/patch_wagtailadmin.py
+++ b/wagtail_modeltranslation/patch_wagtailadmin.py
@@ -55,7 +55,7 @@ class WagtailTranslator(object):
         if hasattr(model, 'edit_handler'):
             tabs = model.edit_handler.children
 
-            for tab in tabs.children:
+            for tab in tabs:
                 tab.children = self._patch_panels(tab.children)
 
         else:


### PR DESCRIPTION
When patching page models `patch_wagtailadmin.py` includes an extra `.children`. This addresses #107 

This PR removes the extra `.children` for tabs from `model.edit_handler`