### PR TITLE
Switched __bases__ to issubclass in translator.py

### DIFF
--- a/wagtail_modeltranslation/translator.py
+++ b/wagtail_modeltranslation/translator.py
@@ -4,7 +4,7 @@ from modeltranslation.translator import TranslationOptions
 class WagtailTranslationOptions(TranslationOptions):
     def __init__(self, model):
         from wagtail.wagtailcore.models import Page
-        if Page in model.__bases__:
+        if issubclass(model, Page):
             self.fields += (
                 'title',
                 'slug',


### PR DESCRIPTION
This PR changes the way `wagtail_modeltranslation` detects whether or a not a particular model is based on Wagtail `Page` model. This is to address #106. 