### PR TITLE
WIP: Do not add Page fields to child models

### DIFF
--- a/wagtail_modeltranslation/translation.py
+++ b/wagtail_modeltranslation/translation.py
@@ -7,4 +7,10 @@ from wagtail.wagtailcore.models import Page
 
 @register(Page)
 class PageTR(TranslationOptions):
-    pass
+    fields = (
+        'title',
+        'slug',
+        'seo_title',
+        'search_description',
+        'url_path',
+    )

--- a/wagtail_modeltranslation/translator.py
+++ b/wagtail_modeltranslation/translator.py
@@ -2,14 +2,4 @@ from modeltranslation.translator import TranslationOptions
 
 
 class WagtailTranslationOptions(TranslationOptions):
-    def __init__(self, model):
-        from wagtail.wagtailcore.models import Page
-        if Page in model.__bases__:
-            self.fields += (
-                'title',
-                'slug',
-                'seo_title',
-                'search_description',
-                'url_path',)
-
-        super(WagtailTranslationOptions, self).__init__(model)
+    pass


### PR DESCRIPTION
Register the Page model directly.

The django-modeltranslation project supports inheritance. Adding Page level fields on child models instead of relying on inheritance prevent using i18n when working directly with Page models. 

