### PR TITLE
Added AbstractEmailForm to WagtailTranslationOptions

### DIFF
--- a/wagtail_modeltranslation/translator.py
+++ b/wagtail_modeltranslation/translator.py
@@ -2,9 +2,17 @@ from modeltranslation.translator import TranslationOptions
 
 
 class WagtailTranslationOptions(TranslationOptions):
+
+    @staticmethod
+    def any_in(self, l1, l2):
+        return any(i in l1 for i in l2)
+
     def __init__(self, model):
+
         from wagtail.wagtailcore.models import Page
-        if Page in model.__bases__:
+        from wagtail.wagtailforms.models import AbstractEmailForm
+
+        if self.any_in([Page, AbstractEmailForm], model.__bases__):
             self.fields += (
                 'title',
                 'slug',


### PR DESCRIPTION
Since AbstractEmailForm only indirectly inherits from Page, the 'url' parameter of an AbstractEmailForm's instance will result in None / it's not routable. This fix solves it by explicitly checking for either Page or AbstractEmailForm.

Would you please consider pulling in this change? Thanks!