### PR TITLE
Fix translated required base fields (title, slug…) not required

### DIFF
--- a/wagtail_modeltranslation/patch_wagtailadmin.py
+++ b/wagtail_modeltranslation/patch_wagtailadmin.py
@@ -135,6 +135,11 @@ class WagtailTranslator(object):
         panel_class = original_panel.__class__
         translated_panels = []
         translation_registered_fields = translator.get_options_for_model(model).fields
+        translation_required_fields = getattr(
+            translator.get_options_for_model(model),
+            'required_languages',
+            None
+        )
 
         # If the panel field is not registered for translation
         # the original one is returned
@@ -145,9 +150,17 @@ class WagtailTranslator(object):
             original_field = model._meta.get_field(original_panel.field_name)
             localized_field_name = build_localized_fieldname(original_panel.field_name, language)
 
-            # if the original field is required and the current language is the default one
-            # this field's blank property is set to False
-            if not original_field.blank and language == mt_settings.DEFAULT_LANGUAGE:
+            if isinstance(translation_required_fields, tuple):
+                is_required = language in translation_required_fields
+            elif isinstance(translation_required_fields, dict):
+                is_required = original_field.name in 
+                    translation_required_fields[language]
+            else:
+                is_required = false
+
+            # if the original field is required and is_required, this field's
+            # blank property is set to False
+            if not original_field.blank and is_required:
                 localized_field = model._meta.get_field(localized_field_name)
                 localized_field.blank = False
 

--- a/wagtail_modeltranslation/patch_wagtailadmin.py
+++ b/wagtail_modeltranslation/patch_wagtailadmin.py
@@ -153,8 +153,7 @@ class WagtailTranslator(object):
             if isinstance(translation_required_fields, tuple):
                 is_required = language in translation_required_fields
             elif isinstance(translation_required_fields, dict):
-                is_required = original_field.name in 
-                    translation_required_fields[language]
+                is_required = original_field.name in translation_required_fields[language]
             else:
                 is_required = false
 


### PR DESCRIPTION
This PR correct issue #87 still present in the v0.6.0rc2 when base Wagtail fields (such as `title` or `slug`) are not made mandatory in the admin panels, even if a `TranslationOption` set it to required in `required_languages`.