### PR TITLE
Pull request fix page copy

### DIFF
--- a/wagtail_modeltranslation/patch_wagtailadmin_forms.py
+++ b/wagtail_modeltranslation/patch_wagtailadmin_forms.py
@@ -27,7 +27,7 @@ class PatchedCopyForm(CopyForm):
         for code, name in settings.LANGUAGES:
             locale_title = "new_slug_{}".format(code)
             locale_label = "{} [{}]".format(_("New slug"), code)
-            self.fields[locale_title] = forms.CharField(initial=self.page.title, label=locale_label)
+            self.fields[locale_title] = forms.SlugField(initial=self.page.slug, label=locale_label)
 
         self.fields['new_parent_page'] = forms.ModelChoiceField(
             initial=self.page.get_parent(),

--- a/wagtail_modeltranslation/patch_wagtailadmin_forms.py
+++ b/wagtail_modeltranslation/patch_wagtailadmin_forms.py
@@ -1,0 +1,101 @@
+# coding: utf-8
+
+from django import forms
+from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy, ungettext
+from wagtail.wagtailcore.models import Page
+from wagtail.wagtailadmin import widgets
+from wagtail.wagtailadmin.forms import CopyForm
+
+
+class PatchedCopyForm(CopyForm):
+    def __init__(self, *args, **kwargs):
+        # CopyPage must be passed a 'page' kwarg indicating the page to be copied
+        self.page = kwargs.pop('page')
+        self.user = kwargs.pop('user', None)
+        can_publish = kwargs.pop('can_publish')
+        super(CopyForm, self).__init__(*args, **kwargs)
+
+        #self.fields['new_title'] = forms.CharField(initial=self.page.title, label=_("New title"))
+        for language in ('fr', 'en'):
+            locale_title = "new_title_{}".format(language)
+            locale_label = "{} [{}]".format(_("New title"), language)
+            self.fields[locale_title] = forms.CharField(initial=self.page.title, label=locale_label)
+
+        #self.fields['new_slug'] = forms.SlugField(initial=self.page.slug, label=_("New slug"))
+        for language in ('fr', 'en'):
+            locale_title = "new_slug_{}".format(language)
+            locale_label = "{} [{}]".format(_("New slug"), language)
+            self.fields[locale_title] = forms.CharField(initial=self.page.title, label=locale_label)
+
+        self.fields['new_parent_page'] = forms.ModelChoiceField(
+            initial=self.page.get_parent(),
+            queryset=Page.objects.all(),
+            widget=widgets.AdminPageChooser(can_choose_root=True, user_perms='copy_to'),
+            label=_("New parent page"),
+            help_text=_("This copy will be a child of this given parent page.")
+        )
+        pages_to_copy = self.page.get_descendants(inclusive=True)
+        subpage_count = pages_to_copy.count() - 1
+        if subpage_count > 0:
+            self.fields['copy_subpages'] = forms.BooleanField(
+                required=False, initial=True, label=_("Copy subpages"),
+                help_text=ungettext(
+                    "This will copy %(count)s subpage.",
+                    "This will copy %(count)s subpages.",
+                    subpage_count) % {'count': subpage_count})
+
+        if can_publish:
+            pages_to_publish_count = pages_to_copy.live().count()
+            if pages_to_publish_count > 0:
+                # In the specific case that there are no subpages, customise the field label and help text
+                if subpage_count == 0:
+                    label = _("Publish copied page")
+                    help_text = _("This page is live. Would you like to publish its copy as well?")
+                else:
+                    label = _("Publish copies")
+                    help_text = ungettext(
+                        "%(count)s of the pages being copied is live. Would you like to publish its copy?",
+                        "%(count)s of the pages being copied are live. Would you like to publish their copies?",
+                        pages_to_publish_count) % {'count': pages_to_publish_count}
+
+                self.fields['publish_copies'] = forms.BooleanField(
+                    required=False, initial=True, label=label, help_text=help_text
+                )
+
+    def clean(self):
+        cleaned_data = super(CopyForm, self).clean()
+
+        # Make sure the slug isn't already in use
+        #slug = cleaned_data.get('new_slug')
+
+        # New parent page given in form or parent of source, if parent_page is empty
+        parent_page = cleaned_data.get('new_parent_page') or self.page.get_parent()
+
+        # check if user is allowed to create a page at given location.
+        if not parent_page.permissions_for_user(self.user).can_add_subpage():
+            self._errors['new_parent_page'] = self.error_class([
+                _("You do not have permission to copy to page \"%(page_title)s\"") % {'page_title': parent_page.get_admin_display_title()}
+            ])
+
+        # Count the pages with the same slug within the context of our copy's parent page
+        for language in ('fr', 'en'):
+            locale_slug = "slug_{}".format(language)
+            slug = cleaned_data.get(locale_slug)
+
+            if slug and parent_page.get_children().filter(slug=slug).count():
+                self._errors['new_slug'] = self.error_class(
+                    [_("This slug is already in use within the context of its parent page \"%s\"" % parent_page)]
+                )
+                # The slug is no longer valid, hence remove it from cleaned_data
+                del cleaned_data['new_slug']
+
+        # Don't allow recursive copies into self
+        if cleaned_data.get('copy_subpages') and (self.page == parent_page or parent_page.is_descendant_of(self.page)):
+            self._errors['new_parent_page'] = self.error_class(
+                [_("You cannot copy a page into itself when copying subpages")]
+            )
+
+        return cleaned_data
+     
+

--- a/wagtail_modeltranslation/patch_wagtailadmin_forms.py
+++ b/wagtail_modeltranslation/patch_wagtailadmin_forms.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 
 from django import forms
+from django.conf import settings
 from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_lazy, ungettext
 from wagtail.wagtailcore.models import Page
@@ -17,15 +18,15 @@ class PatchedCopyForm(CopyForm):
         super(CopyForm, self).__init__(*args, **kwargs)
 
         #self.fields['new_title'] = forms.CharField(initial=self.page.title, label=_("New title"))
-        for language in ('fr', 'en'):
-            locale_title = "new_title_{}".format(language)
-            locale_label = "{} [{}]".format(_("New title"), language)
+        for code, name in settings.LANGUAGES:
+            locale_title = "new_title_{}".format(code)
+            locale_label = "{} [{}]".format(_("New title"), code)
             self.fields[locale_title] = forms.CharField(initial=self.page.title, label=locale_label)
 
         #self.fields['new_slug'] = forms.SlugField(initial=self.page.slug, label=_("New slug"))
-        for language in ('fr', 'en'):
-            locale_title = "new_slug_{}".format(language)
-            locale_label = "{} [{}]".format(_("New slug"), language)
+        for code, name in settings.LANGUAGES:
+            locale_title = "new_slug_{}".format(code)
+            locale_label = "{} [{}]".format(_("New slug"), code)
             self.fields[locale_title] = forms.CharField(initial=self.page.title, label=locale_label)
 
         self.fields['new_parent_page'] = forms.ModelChoiceField(
@@ -79,8 +80,8 @@ class PatchedCopyForm(CopyForm):
             ])
 
         # Count the pages with the same slug within the context of our copy's parent page
-        for language in ('fr', 'en'):
-            locale_slug = "slug_{}".format(language)
+        for code, name in settings.LANGUAGES:
+            locale_slug = "slug_{}".format(code)
             slug = cleaned_data.get(locale_slug)
 
             if slug and parent_page.get_children().filter(slug=slug).count():

--- a/wagtail_modeltranslation/templates/modeltranslation_copy.html
+++ b/wagtail_modeltranslation/templates/modeltranslation_copy.html
@@ -18,10 +18,6 @@
                 {% if form.copy_subpages %}
                     {% include "wagtailadmin/shared/field_as_li.html" with field=form.copy_subpages %}
                 {% endif %}
-
-                {% if form.publish_copies %}
-                    {% include "wagtailadmin/shared/field_as_li.html" with field=form.publish_copies %}
-                {% endif %}
             </ul>
 
             <input type="submit" value="{% trans 'Copy this page' %}" class="button">

--- a/wagtail_modeltranslation/templates/modeltranslation_copy.html
+++ b/wagtail_modeltranslation/templates/modeltranslation_copy.html
@@ -9,12 +9,11 @@
         <form action="{% url 'wagtailadmin_pages:copy' page.id %}" method="POST" novalidate>
             {% csrf_token %}
             <input type="hidden" name="next" value="{{ next }}" />
-            <h1>Wagtail modeltranslation copy</h1>
 
             <ul class="fields">
-                {% include "wagtailadmin/shared/field_as_li.html" with field=form.new_title %}
-                {% include "wagtailadmin/shared/field_as_li.html" with field=form.new_slug %}
-                {% include "wagtailadmin/shared/field_as_li.html" with field=form.new_parent_page %}
+                {% for field in form.visible_fields %}
+             	    {% include "wagtailadmin/shared/field_as_li.html" with field=field %}
+             	{% endfor %}
 
                 {% if form.copy_subpages %}
                     {% include "wagtailadmin/shared/field_as_li.html" with field=form.copy_subpages %}

--- a/wagtail_modeltranslation/templates/modeltranslation_copy.html
+++ b/wagtail_modeltranslation/templates/modeltranslation_copy.html
@@ -1,0 +1,36 @@
+{% extends "wagtailadmin/base.html" %}
+{% load i18n %}
+{% block titletag %}{% blocktrans with title=page.get_admin_display_title %}Copy {{ title }}{% endblocktrans %}{% endblock %}
+{% block content %}
+    {% trans "Copy" as copy_str %}
+    {% include "wagtailadmin/shared/header.html" with title=copy_str subtitle=page.get_admin_display_title icon="doc-empty-inverse" %}
+
+    <div class="nice-padding">
+        <form action="{% url 'wagtailadmin_pages:copy' page.id %}" method="POST" novalidate>
+            {% csrf_token %}
+            <input type="hidden" name="next" value="{{ next }}" />
+            <h1>Wagtail modeltranslation copy</h1>
+
+            <ul class="fields">
+                {% include "wagtailadmin/shared/field_as_li.html" with field=form.new_title %}
+                {% include "wagtailadmin/shared/field_as_li.html" with field=form.new_slug %}
+                {% include "wagtailadmin/shared/field_as_li.html" with field=form.new_parent_page %}
+
+                {% if form.copy_subpages %}
+                    {% include "wagtailadmin/shared/field_as_li.html" with field=form.copy_subpages %}
+                {% endif %}
+
+                {% if form.publish_copies %}
+                    {% include "wagtailadmin/shared/field_as_li.html" with field=form.publish_copies %}
+                {% endif %}
+            </ul>
+
+            <input type="submit" value="{% trans 'Copy this page' %}" class="button">
+        </form>
+    </div>
+{% endblock %}
+
+{% block extra_js %}
+    {{ block.super }}
+    {% include "wagtailadmin/pages/_editor_js.html" %}
+{% endblock %}

--- a/wagtail_modeltranslation/wagtail_hooks.py
+++ b/wagtail_modeltranslation/wagtail_hooks.py
@@ -183,9 +183,9 @@ def before_copy_page(request, page):
             can_publish = parent_page.permissions_for_user(request.user).can_publish_subpage()
 
             update_attrs = {}
-            for language in ('fr', 'en'):
-                slug = "slug_{}".format(language)
-                title = "title_{}".format(language)
+            for code, name in settings.LANGUAGES:
+                slug = "slug_{}".format(code)
+                title = "title_{}".format(code)
                 update_attrs[slug] = form.cleaned_data["new_{}".format(slug)]
                 update_attrs[title] = form.cleaned_data["new_{}".format(title)]
 

--- a/wagtail_modeltranslation/wagtail_hooks.py
+++ b/wagtail_modeltranslation/wagtail_hooks.py
@@ -2,6 +2,8 @@
 
 import json
 
+from django import forms
+from django.shortcuts import render
 from django.conf import settings
 from django.conf.urls import url
 from django.http import HttpResponse
@@ -12,7 +14,18 @@ from six import iteritems
 from wagtail.wagtailcore import hooks
 from wagtail.wagtailcore.models import Page
 from wagtail.wagtailcore.rich_text import PageLinkHandler
+from wagtail.wagtailadmin.forms import CopyForm
 
+# Required for PatchedCopyForm
+from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy, ungettext
+
+# TODO: Already in wagtail, replace with proper import
+def get_valid_next_url_from_request(request):
+    next_url = request.POST.get('next') or request.GET.get('next')
+    if not next_url or not is_safe_url(url=next_url, host=request.get_host()):
+        return ''
+    return next_url
 
 @hooks.register('insert_editor_js')
 def translated_slugs():
@@ -142,3 +155,31 @@ def register_localized_page_link_handler():
                 return "<a>"
 
     return ('page', LocalizedPageLinkHandler)
+
+class PatchedCopyForm(CopyForm):
+
+    def __init__(self, *args, **kwargs):
+        self.page = kwargs.pop('page')
+        self.user = kwargs.pop('user', None)
+        can_publish = kwargs.pop('can_publish')
+        super(CopyForm, self).__init__(*args, **kwargs)
+
+        for language in ('fr', 'en'):
+            title_initial = self.page.title+"_"+language
+            title_label = "new_title_"+language
+            self.fields[title_label] = forms.SlugField(initial=title_initial, label=_("New title"))
+            slug_initial = self.page.slug+"_"+language
+            slug_label = "new_slug_"+language
+            self.fields[slug_label] = forms.SlugField(initial=slug_initial, label=_("New slug"))
+         
+@hooks.register('before_copy_page')
+def before_copy_page(request, page):
+    parent_page = page.get_parent()
+    can_publish = parent_page.permissions_for_user(request.user).can_publish_subpage()
+    form = PatchedCopyForm(request.POST or None, user=request.user, page=page, can_publish=can_publish)
+    next_url = get_valid_next_url_from_request(request)
+    return render(request, 'modeltranslation_copy.html', {
+        'page': page,
+        'form': form,
+        'next': next_url
+    })


### PR DESCRIPTION
In the last v0.6.0rc2 copying pages isn't functionnal. This PR allow copying Wagtail pages by hooking into `before_page_copy` and overriding page copy process :

* Wagtail's copy function is almost duplicated in the hook
* `PatchedCopyForm` now generate `new_title` and `new_slug` fields for every registered languages
* `modeltranslation_copy.html` display as much fields as needed