### PR TITLE
[fix] i18n slugs required specific page in order to retrieve good url

### DIFF
--- a/wagtail_modeltranslation/patch_wagtailadmin.py
+++ b/wagtail_modeltranslation/patch_wagtailadmin.py
@@ -328,7 +328,7 @@ def _new_relative_url(self, current_site):
     for (id, root_path, root_url) in self.get_site_root_paths():
         if self.url_path.startswith(root_path):
             return ('' if current_site.id == id else root_url) + reverse('wagtail_serve',
-                                                                         args=(self.url_path[len(root_path):],))
+                                                                         args=(self.specific.url_path[len(root_path):],))
 
 
 @property


### PR DESCRIPTION
without this fix translated slugs are not retrieved as expected, because translated version are available on specific page.