### PR TITLE
Fix update_translation_fields command

### DIFF
--- a/wagtail_modeltranslation/management/commands/update_translation_fields.py
+++ b/wagtail_modeltranslation/management/commands/update_translation_fields.py
@@ -8,16 +8,6 @@ from modeltranslation.utils import build_localized_fieldname
 from wagtail.wagtailcore.models import Page
 
 
-def is_field_from_parents(field_name, model):
-    for klass in model.__bases__:
-        if field_name in klass.__dict__:
-            return klass
-        field_klass = is_field_from_parents(field_name, klass)
-        if field_klass:
-            return field_klass
-    return None
-
-
 class Command(BaseCommand):
     help = ('Updates empty values of default translation fields using'
             ' values from original fields (in all translated models).')
@@ -47,7 +37,7 @@ class Command(BaseCommand):
                         original_field = obj.__dict__.get(field_name)  # retrieve original untranslated value
                         setattr(obj, def_lang_fieldname, original_field)
 
-                        # patching Page.full_clean() to avoid validation errors due to slug and title absence
+                        # patching Page.full_clean() to avoid validation errors due to 'slug_xx' and 'title_xx' absence
                         original_full_clean = obj.full_clean
                         obj.full_clean = lambda *args: None
                         obj.save(update_fields=[def_lang_fieldname])


### PR DESCRIPTION
Addresses issue #103.

Key changes:

- No more raw queries to DB;
- Fetches original field value using `obj.__dict__.get(field_name)` as suggested by modeltranslation [docs](http://django-modeltranslation.readthedocs.io/en/latest/usage.html#the-state-of-the-original-field);
- Monkey patches `Page.full_clean()` to avoid validation errors due to 'slug_xx' and 'title_xx' absences. Note that Django's `Model.save()` itself does not call `full_clean()`, it's `Page.save()` that does it. More about this [here](https://github.com/wagtail/wagtail/issues/3511#issuecomment-339614011) and [here](https://code.djangoproject.com/ticket/13100#comment:2).

Tested with django v1.10, wagtail v1.6.3 and django-modeltranslation v0.12.1.