### PR TITLE
Remove .specific call to save DB queries

### DIFF
--- a/wagtail_modeltranslation/patch_wagtailadmin.py
+++ b/wagtail_modeltranslation/patch_wagtailadmin.py
@@ -4,7 +4,6 @@ import logging
 import types
 
 from django.core.exceptions import ValidationError, FieldDoesNotExist
-from django.core.urlresolvers import reverse
 from django.db import transaction, connection
 from django.http import Http404
 from django.utils.translation import trans_real
@@ -17,7 +16,7 @@ from wagtail.contrib.settings.views import get_setting_edit_handler
 from wagtail.contrib.wagtailroutablepage.models import RoutablePageMixin
 from wagtail.wagtailadmin.edit_handlers import FieldPanel, \
     MultiFieldPanel, FieldRowPanel, InlinePanel, StreamFieldPanel, RichTextFieldPanel
-from wagtail.wagtailcore.models import Page, Site
+from wagtail.wagtailcore.models import Page
 from wagtail.wagtailcore.fields import StreamField, StreamValue
 from wagtail.wagtailcore.url_routing import RouteResult
 from wagtail.wagtailimages.edit_handlers import ImageChooserPanel
@@ -300,7 +299,7 @@ def _validate_slugs(page):
     # Save the current active language
     current_language = get_language()
 
-    siblings = page.get_siblings(inclusive=False).specific()
+    siblings = page.get_siblings(inclusive=False)
 
     errors = {}
 
@@ -313,7 +312,7 @@ def _validate_slugs(page):
 
         siblings_slugs = [sibling.slug for sibling in siblings]
 
-        if page.specific.slug in siblings_slugs:
+        if page.slug in siblings_slugs:
             errors[build_localized_fieldname('slug', language)] = _("This slug is already in use")
 
     # Re-enable the original language

--- a/wagtail_modeltranslation/patch_wagtailadmin.py
+++ b/wagtail_modeltranslation/patch_wagtailadmin.py
@@ -277,7 +277,7 @@ def _new_route(self, request, path_components):
 
         subpages = self.get_children()
         for page in subpages:
-            if page.specific.slug == child_slug:
+            if page.slug == child_slug:
                 return page.specific.route(request, remaining_components)
         raise Http404
 

--- a/wagtail_modeltranslation/patch_wagtailadmin.py
+++ b/wagtail_modeltranslation/patch_wagtailadmin.py
@@ -107,9 +107,6 @@ class WagtailTranslator(object):
         # OVERRIDE PAGE METHODS
         model.set_url_path = _new_set_url_path
         model.route = _new_route
-        model.get_site_root_paths = _new_get_site_root_paths
-        model.relative_url = _new_relative_url
-        model.url = _new_url
         _patch_clean(model)
 
         if not model.save.__name__.startswith('localized'):
@@ -287,61 +284,6 @@ def _new_route(self, request, path_components):
             return RouteResult(self)
         else:
             raise Http404
-
-
-@staticmethod
-def _new_get_site_root_paths():
-    """
-    Return a list of (root_path, root_url) tuples, most specific path first -
-    used to translate url_paths into actual URLs with hostnames
-
-    Same method as Site.get_site_root_paths() but without cache
-
-    TODO: remake this method with cache and think of his integration in
-    Site.get_site_root_paths()
-    """
-    result = [
-        (site.id, site.root_page.specific.url_path, site.root_url)
-        for site in Site.objects.select_related('root_page').order_by('-root_page__url_path')
-    ]
-
-    return result
-
-
-def _new_relative_url(self, current_site):
-    """
-    Return the 'most appropriate' URL for this page taking into account the site we're currently on;
-    a local URL if the site matches, or a fully qualified one otherwise.
-    Return None if the page is not routable.
-
-    Override for using custom get_site_root_paths() instead of
-    Site.get_site_root_paths()
-    """
-    for (id, root_path, root_url) in self.get_site_root_paths():
-        if self.url_path.startswith(root_path):
-            return ('' if current_site.id == id else root_url) + reverse('wagtail_serve',
-                                                                         args=(self.specific.url_path[len(root_path):],))
-
-
-@property
-def _new_url(self):
-    """
-    Return the 'most appropriate' URL for referring to this page from the pages we serve,
-    within the Wagtail backend and actual website templates;
-    this is the local URL (starting with '/') if we're only running a single site
-    (i.e. we know that whatever the current page is being served from, this link will be on the
-    same domain), and the full URL (with domain) if not.
-    Return None if the page is not routable.
-
-    Override for using custom get_site_root_paths() instead of
-    Site.get_site_root_paths()
-    """
-    root_paths = self.get_site_root_paths()
-
-    for (id, root_path, root_url) in root_paths:
-        if self.url_path.startswith(root_path):
-            return ('' if len(root_paths) == 1 else root_url) + reverse(
-                'wagtail_serve', args=(self.url_path[len(root_path):],))
 
 
 def _validate_slugs(page):

--- a/wagtail_modeltranslation/tests/models.py
+++ b/wagtail_modeltranslation/tests/models.py
@@ -1,6 +1,8 @@
 # coding: utf-8
 from django.db import models
+from django.http import HttpResponse
 from modelcluster.fields import ParentalKey
+from wagtail.contrib.wagtailroutablepage.models import RoutablePageMixin, route
 from wagtail.wagtailadmin.edit_handlers import FieldPanel, MultiFieldPanel, FieldRowPanel, InlinePanel, StreamFieldPanel
 from wagtail.wagtailcore import blocks
 from wagtail.wagtailcore.fields import StreamField
@@ -24,8 +26,10 @@ class TestSlugPage1(WagtailPage):
 class TestSlugPage2(WagtailPage):
     pass
 
+
 class TestSlugPage1Subclass(TestSlugPage1):
     pass
+
 
 class PatchTestPage(WagtailPage):
     description = models.CharField(max_length=50)
@@ -193,3 +197,13 @@ class InlinePanelPage(WagtailPage):
     content_panels = [
         InlinePanel('related_page_model')
     ]
+
+
+class RoutablePageTest(RoutablePageMixin, WagtailPage):
+    @route(r'^archive/year/1984/$')
+    def archive_for_1984(self, request):
+        return HttpResponse("we were always at war with eastasia")
+
+    @route(r'^archive/year/(\d+)/$')
+    def archive_by_year(self, request, year):
+        return HttpResponse("ARCHIVE BY YEAR: " + str(year))

--- a/wagtail_modeltranslation/tests/tests.py
+++ b/wagtail_modeltranslation/tests/tests.py
@@ -352,7 +352,11 @@ class WagtailModeltranslationTest(WagtailModeltranslationTestBase):
 
         # Make the slug equal to test if the duplicate is detected
         child2.slug_de = 'child'
+        self.assertRaises(ValidationError, child2.clean)
+        child2.slug_de = 'child-2'
 
+        # Make the translated slug equal to test if the duplicate is detected
+        child2.slug_en = 'child-en'
         self.assertRaises(ValidationError, child2.clean)
 
     def test_slugurl_trans(self):

--- a/wagtail_modeltranslation/tests/tests.py
+++ b/wagtail_modeltranslation/tests/tests.py
@@ -589,7 +589,7 @@ class WagtailModeltranslationTest(WagtailModeltranslationTestBase):
         """
         site_pages = {
             'model': models.TestRootPage,
-            'kwargs': {'title': 'root untranslated',},
+            'kwargs': {'title': 'root untranslated', },
             'children': {
                 'child': {
                     'model': models.TestSlugPage1,
@@ -749,3 +749,65 @@ class WagtailModeltranslationTest(WagtailModeltranslationTestBase):
         self.assertEqual(args, ('2014',))
         self.assertEqual(kwargs, {})
         self.check_route_request(root_page, ['routing-en-03', 'routing-en-0301'], page_0301)
+
+    def test_get_url_parts(self):
+        site_pages = {
+            'model': models.TestRootPage,
+            'kwargs': {'title': 'root URL parts', },
+            'children': {
+                'child1': {
+                    'model': models.TestSlugPage1,
+                    'kwargs': {'title': 'child1 URL parts', 'slug_de': 'url-parts-de-01', 'slug_en': 'url-parts-en-01'},
+                },
+                'child2': {
+                    'model': models.TestSlugPage1,
+                    'kwargs': {'title': 'child2 URL parts', 'slug': 'url-parts-de-02'},
+                },
+            },
+        }
+        site = page_factory.create_page_tree(site_pages)
+
+        root_page = site_pages['instance']
+        page_01 = site_pages['children']['child1']['instance']
+        page_02 = site_pages['children']['child2']['instance']
+
+        self.assertEqual(root_page.relative_url(site), '/de/')
+        self.assertEqual(page_01.relative_url(site), '/de/url-parts-de-01/')
+        self.assertEqual(page_02.relative_url(site), '/de/url-parts-de-02/')
+
+        trans_real.activate('en')
+
+        self.assertEqual(root_page.relative_url(site), '/en/')
+        self.assertEqual(page_01.relative_url(site), '/en/url-parts-en-01/')
+        self.assertEqual(page_02.relative_url(site), '/en/url-parts-de-02/')
+
+    def test_url(self):
+        site_pages = {
+            'model': models.TestRootPage,
+            'kwargs': {'title': 'root URL', },
+            'children': {
+                'child1': {
+                    'model': models.TestSlugPage1,
+                    'kwargs': {'title': 'child1 URL', 'slug_de': 'url-de-01', 'slug_en': 'url-en-01'},
+                },
+                'child2': {
+                    'model': models.TestSlugPage2,
+                    'kwargs': {'title': 'child2 URL', 'slug': 'url-de-02'},
+                },
+            },
+        }
+        page_factory.create_page_tree(site_pages)
+
+        root_page = site_pages['instance']
+        page_01 = site_pages['children']['child1']['instance']
+        page_02 = site_pages['children']['child2']['instance']
+
+        self.assertEqual(root_page.url, '/de/')
+        self.assertEqual(page_01.url, '/de/url-de-01/')
+        self.assertEqual(page_02.url, '/de/url-de-02/')
+
+        trans_real.activate('en')
+
+        self.assertEqual(root_page.url, '/en/')
+        self.assertEqual(page_01.url, '/en/url-en-01/')
+        self.assertEqual(page_02.url, '/en/url-de-02/')

--- a/wagtail_modeltranslation/tests/translation.py
+++ b/wagtail_modeltranslation/tests/translation.py
@@ -5,9 +5,7 @@ from wagtail_modeltranslation.tests.models import TestRootPage, TestSlugPage1, T
     PatchTestSnippet, FieldPanelPage, ImageChooserPanelPage, FieldRowPanelPage, MultiFieldPanelPage, InlinePanelPage, \
     FieldPanelSnippet, ImageChooserPanelSnippet, FieldRowPanelSnippet, MultiFieldPanelSnippet, PageInlineModel, \
     BaseInlineModel, StreamFieldPanelPage, StreamFieldPanelSnippet, SnippetInlineModel, InlinePanelSnippet, \
-    TestSlugPage1Subclass
-
-from wagtail.wagtailcore.models import Page
+    TestSlugPage1Subclass, RoutablePageTest
 
 
 # Wagtail Models
@@ -107,3 +105,8 @@ class InlinePanelModelTranslationOptions(TranslationOptions):
 
 
 translator.register(InlinePanelSnippet, InlinePanelModelTranslationOptions)
+
+
+@register(RoutablePageTest)
+class RoutablePageTestTranslationOptions(TranslationOptions):
+    fields = ()


### PR DESCRIPTION
Follow up to PR #150.

For each `Page.specific` call removed a working test was added to ensure nothing would break.