### PR TITLE
Fix makemigrations bug when Page has dependencies

### DIFF
--- a/wagtail_modeltranslation/management/commands/makemigrations_translation.py
+++ b/wagtail_modeltranslation/management/commands/makemigrations_translation.py
@@ -1,18 +1,30 @@
 from django.core.management.commands.makemigrations import Command as MakeMigrationsCommand
 from django.db.migrations.autodetector import MigrationAutodetector
+import copy
 
 
-# decorate MigrationAutodetector.changes so we can silently remove wagtailcore changes
-def changes_decorator(func):
-    def wrapper(self, graph, trim_to_apps=None, convert_apps=None, migration_name=None):
-        changes = func(self, graph, trim_to_apps, convert_apps, migration_name)
-        if 'wagtailcore' in changes:
-            del changes['wagtailcore']
-        return changes
+def autodetector_decorator(func):
+    def wrapper(self, from_state, to_state, questioner=None):
+        # Replace to_state.app_configs.models and to_state.models' version of page with the old one
+        # so no changes are detected by MigrationAutodetector
+        from_state_page = from_state.concrete_apps.get_model('wagtailcore', 'page')
+        new_to_state = copy.deepcopy(to_state)
+        new_to_state.apps.app_configs['wagtailcore'].models['page'] = from_state_page
+        new_to_state.models['wagtailcore', 'page'] = from_state.models['wagtailcore', 'page']
+
+        return func(self, from_state, new_to_state, questioner)
     return wrapper
-
-MigrationAutodetector.changes = changes_decorator(MigrationAutodetector.changes)
 
 
 class Command(MakeMigrationsCommand):
-    help = "Creates new migration(s) for apps except wagtailcore."
+    help = "Creates new migration(s) for apps except wagtailcore's Page."
+
+    def handle(self, *args, **options):
+        old_autodetector_init = MigrationAutodetector.__init__
+        MigrationAutodetector.__init__ = autodetector_decorator(MigrationAutodetector.__init__)
+
+        try:
+            super(Command, self).handle(*args, **options)
+
+        finally:
+            MigrationAutodetector.__init__ = old_autodetector_init


### PR DESCRIPTION
@DiogoMarques29, I believe I found a solution for the issue you've raised in https://github.com/infoportugal/wagtail-modeltranslation/pull/150#issuecomment-354156263. Essentially this fools `MigrationAutodetector` to think nothing's changed between the old version of Page and the new one.

The advantage I see in this strategy over relying on `if 'makemigrations' in sys.argv:` is that `makemigrations` can safely be used programmatically.