### PR TITLE
Add support for Wagtail 1.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: python
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
 env:
   - WAGTAIL="wagtail>=1.4,<1.5"
   - WAGTAIL="wagtail>=1.5,<1.6"
@@ -11,9 +11,12 @@ env:
   - WAGTAIL="wagtail>=1.7,<1.8"
   - WAGTAIL="wagtail>=1.8,<1.9"
   - WAGTAIL="wagtail>=1.9,<1.10"
+  - WAGTAIL="wagtail>=1.10,<1.11"
+  - WAGTAIL="wagtail>=1.11,<1.12"
+  - WAGTAIL="wagtail>=1.12,<1.13"
+  - WAGTAIL="wagtail>=1.13,<1.14"
 install:
   - pip install --upgrade -q pip setuptools
-  - if [[ $TRAVIS_PYTHON_VERSION == '3.3' ]]; then pip install 'Django>=1.8,<1.9'; fi
   - pip install -q $WAGTAIL
   - pip install --process-dependency-links -e .
 script:


### PR DESCRIPTION
This PR patches `Page._update_descendant_url_paths()` to add `.rewrite(False)` to its queryset. It also updates `_localized_update_descendant_url_paths()` to replace raw SQL for a queryset inspired on Wagtail's 1.13 changes.

Travis config was updated to include Wagtail 1.10-1.13 versions and Python 3.3 was replaced for 3.6 (to match Wagtail's own tests).

Note, travis build is taking a considerable amount of time, we should consider dropping some Wagtail or Python versions. Perhaps after releasing v0.8 final.
  