### PR TITLE
Remove _new_relative_url and _new_url methods

### DIFF
--- a/wagtail_modeltranslation/patch_wagtailadmin.py
+++ b/wagtail_modeltranslation/patch_wagtailadmin.py
@@ -288,42 +288,6 @@ def _new_route(self, request, path_components):
             raise Http404
 
 
-def _new_relative_url(self, current_site, request=None):
-    """
-    Return the 'most appropriate' URL for this page taking into account the site we're currently on;
-    a local URL if the site matches, or a fully qualified one otherwise.
-    Return None if the page is not routable.
-
-    Override for using custom get_site_root_paths() instead of
-    Site.get_site_root_paths()
-    """
-    for (id, root_path, root_url) in self.get_site_root_paths():
-        if self.url_path.startswith(root_path):
-            return ('' if current_site.id == id else root_url) + reverse('wagtail_serve',
-                                                                         args=(self.specific.url_path[len(root_path):],))
-
-
-@property
-def _new_url(self):
-    """
-    Return the 'most appropriate' URL for referring to this page from the pages we serve,
-    within the Wagtail backend and actual website templates;
-    this is the local URL (starting with '/') if we're only running a single site
-    (i.e. we know that whatever the current page is being served from, this link will be on the
-    same domain), and the full URL (with domain) if not.
-    Return None if the page is not routable.
-
-    Override for using custom get_site_root_paths() instead of
-    Site.get_site_root_paths()
-    """
-    root_paths = self.get_site_root_paths()
-
-    for (id, root_path, root_url) in root_paths:
-        if self.url_path.startswith(root_path):
-            return ('' if len(root_paths) == 1 else root_url) + reverse(
-                'wagtail_serve', args=(self.url_path[len(root_path):],))
-
-
 def _validate_slugs(page):
     """
     Determine whether the given slug is available for use on a child page of


### PR DESCRIPTION
These had been removed before but were reintroduced during `experimental` branch merge.