### PR TITLE
Remove extraneous Meta class from PageTR

### DIFF
--- a/wagtail_modeltranslation/translation.py
+++ b/wagtail_modeltranslation/translation.py
@@ -7,9 +7,6 @@ from wagtail.wagtailcore.models import Page
 
 @register(Page)
 class PageTR(TranslationOptions):
-    class Meta:
-        managed = False
-
     fields = (
         'title',
         'slug',


### PR DESCRIPTION
This was apparently done by accident on https://github.com/infoportugal/wagtail-modeltranslation/commit/333c392dc8139e0a2cd3256daed56edc9c064142#diff-82b490ec281e50fa1b6e8f2bc765ae3dR10, no reason for `PageTR` to have a meta class with `managed = False`.