### PR TITLE
Travis: reduce number of jobs from 40 to 15

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,9 +35,10 @@ before_script:
   - mysql -e 'create database wagtail_modeltranslation;'
   - psql -c 'create database wagtail_modeltranslation;' -U postgres
 install:
-  - if [[ $DB == mysql ]] && [[ ${PYTHON:0:1} == "2" ]]; then pip install -q mysql-python; elif [[ $DB == mysql ]] && [[ ${PYTHON:0:1} == "3" ]]; then pip install -q mysqlclient; fi
-  - if [[ $DB == postgres ]]; then pip install -q psycopg2; fi
   - pip install --upgrade -q pip setuptools
+  - if [[ $DB == mysql ]] && [[ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]]; then pip install -q mysql-python; elif [[ $DB == mysql ]] && [[ ${TRAVIS_PYTHON_VERSION:0:1} == "3" ]]; then pip install -q mysqlclient; fi
+  - if [[ $DB == postgres ]]; then pip install -q psycopg2; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == '3.3' ]]; then pip install 'Django>=1.8,<1.9'; fi
   - pip install -q $WAGTAIL
   - pip install --process-dependency-links -e .
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,42 @@
 language: python
 python:
-  - "2.7"
-  - "3.4"
-  - "3.5"
   - "3.6"
 env:
-  - WAGTAIL="wagtail>=1.4,<1.5"
-  - WAGTAIL="wagtail>=1.5,<1.6"
-  - WAGTAIL="wagtail>=1.6,<1.7"
-  - WAGTAIL="wagtail>=1.7,<1.8"
-  - WAGTAIL="wagtail>=1.8,<1.9"
-  - WAGTAIL="wagtail>=1.9,<1.10"
-  - WAGTAIL="wagtail>=1.10,<1.11"
-  - WAGTAIL="wagtail>=1.11,<1.12"
-  - WAGTAIL="wagtail>=1.12,<1.13"
-  - WAGTAIL="wagtail>=1.13,<1.14"
+  - WAGTAIL="wagtail>=1.13,<1.14" DB=sqlite
+matrix:
+  include:
+  # Latest Wagtail version
+  - env: WAGTAIL="wagtail>=1.13,<1.14" DB=sqlite
+  - env: WAGTAIL="wagtail>=1.13,<1.14" DB=postgres
+  - env: WAGTAIL="wagtail>=1.13,<1.14" DB=mysql
+  - python: "3.5"
+  - python: "3.4"
+  - python: "2.7"
+  # Past Wagtail versions
+  - python: "3.6"
+    env: WAGTAIL="wagtail>=1.12,<1.13"
+  - python: "3.6"
+    env: WAGTAIL="wagtail>=1.11,<1.12"
+  - python: "3.6"
+    env: WAGTAIL="wagtail>=1.10,<1.11"
+  - python: "3.5"
+    env: WAGTAIL="wagtail>=1.9,<1.10"
+  - python: "3.3" # Wagtail 1.9 was the latest tested against 3.3
+    env: WAGTAIL="wagtail>=1.9,<1.10"
+  - python: "3.5"
+    env: WAGTAIL="wagtail>=1.8,<1.9"
+  - python: "3.5"
+    env: WAGTAIL="wagtail>=1.6,<1.7"
+  - python: "3.5"
+    env: WAGTAIL="wagtail>=1.5,<1.6"
+  - python: "3.5"
+    env: WAGTAIL="wagtail>=1.4,<1.5"
+before_script:
+  - mysql -e 'create database wagtail_modeltranslation;'
+  - psql -c 'create database wagtail_modeltranslation;' -U postgres
 install:
+  - if [[ $DB == mysql ]] && [[ ${PYTHON:0:1} == "2" ]]; then pip install -q mysql-python; elif [[ $DB == mysql ]] && [[ ${PYTHON:0:1} == "3" ]]; then pip install -q mysqlclient; fi
+  - if [[ $DB == postgres ]]; then pip install -q psycopg2; fi
   - pip install --upgrade -q pip setuptools
   - pip install -q $WAGTAIL
   - pip install --process-dependency-links -e .


### PR DESCRIPTION
This PR:

1. Reduces the number of travis jobs by using [matrix include](https://docs.travis-ci.com/user/customizing-the-build/#Explicitly-Including-Jobs);
2. Adds jobs to test latest wagtail version against MySQL and Postgres;
3. Reintroduces one python 3.3 job against the latest Wagtail version that used it in tests - Wagtail 1.9

While this strategy is not as exhaustive as running every combination of Python with all wagtail versions I believe it to be a better balance of time and coverage. Build time was reduced from close to 1h to 21 min.
  