### PR TITLE
Handle None values in old_url_path

### DIFF
--- a/wagtail_modeltranslation/patch_wagtailadmin.py
+++ b/wagtail_modeltranslation/patch_wagtailadmin.py
@@ -364,7 +364,7 @@ def _localized_update_descendant_url_paths(page, old_url_path, new_url_path, lan
             .exclude(pk=page.pk)
             .update(**{localized_url_path: Concat(
                 Value(new_url_path),
-                Substr(localized_url_path, len(old_url_path) + 1))}))
+                Substr(localized_url_path, len(old_url_path or []) + 1))}))
 
 
 def _update_translation_descendant_url_paths(old_record, page):


### PR DESCRIPTION
I am not at all familiar with this part of the codebase, so this approach may be completely off-base, but this modification works for me to fix the issue I reported in #166, where saving a page which has no previous slugs causes an error because `old_url_path` is None and `len()` cannot be called on Nonetype objects. It also just removes the `rewrite(false)` call which was causing an error on my install (no idea if that is the right approach!).