### PR TITLE
Update django-modeltranslation to v0.12.2 and bump version to 0.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from distutils.core import setup
 
 setup(
     name='wagtail-modeltranslation',
-    version='0.8a1',
+    version='0.8',
     description='Translates Wagtail CMS models using a registration approach.',
     long_description=(
         'The modeltranslation application can be used to translate dynamic '
@@ -27,11 +27,8 @@ setup(
         'wagtail_modeltranslation.makemigrations.management.commands'],
     package_data={'wagtail_modeltranslation': ['static/wagtail_modeltranslation/css/*.css',
                                                'static/wagtail_modeltranslation/js/*.js']},
-    install_requires=['wagtail(>=1.4)', 'django-modeltranslation(>0.12.1)'],
-    dependency_links=[
-        "http://github.com/deschler/django-modeltranslation/tarball/00fc7f1804aaa1b1e37af48e67871080851e14b0#egg=django-modeltranslation-0.12.2"
-    ],
-    download_url='https://github.com/infoportugal/wagtail-modeltranslation/archive/v0.8a1.tar.gz',
+    install_requires=['wagtail(>=1.4)', 'django-modeltranslation(>=0.12.2)'],
+    download_url='https://github.com/infoportugal/wagtail-modeltranslation/archive/v0.8.tar.gz',
     classifiers=[
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.6',


### PR DESCRIPTION
Since `modeltranslation` v0.12.2 has been released (https://github.com/deschler/django-modeltranslation/issues/436#issuecomment-360767266), let's use it. Drops dependency-links and bumps `wagtail-modeltranslation` to v0.8.
