### PR TITLE
Make localized StreamField optional (Wagtail >= 1.12)

### DIFF
--- a/wagtail_modeltranslation/patch_wagtailadmin.py
+++ b/wagtail_modeltranslation/patch_wagtailadmin.py
@@ -159,6 +159,14 @@ class WagtailTranslator(object):
             if not original_field.blank and language == mt_settings.DEFAULT_LANGUAGE:
                 localized_field = model._meta.get_field(localized_field_name)
                 localized_field.blank = False
+            elif isinstance(original_field, StreamField):
+                # otherwise the field is optional and
+                # if it's a StreamField the stream_block need to be changed to non required
+                localized_field = model._meta.get_field(localized_field_name)
+                new_stream_block = copy.copy(localized_field.stream_block)
+                new_stream_block.meta = copy.copy(localized_field.stream_block.meta)
+                new_stream_block.meta.required = False
+                localized_field.stream_block = new_stream_block
 
             localized_panel = panel_class(localized_field_name)
 

--- a/wagtail_modeltranslation/tests/models.py
+++ b/wagtail_modeltranslation/tests/models.py
@@ -168,7 +168,7 @@ class FieldRowPanelPage(WagtailPage):
 class StreamFieldPanelPage(WagtailPage):
     body = StreamField([
         ('text', blocks.CharBlock(max_length=10))
-    ])
+    ], blank=False)  # since wagtail 1.12 StreamField's blank defaults to False
 
     content_panels = [
         StreamFieldPanel('body')

--- a/wagtail_modeltranslation/tests/tests.py
+++ b/wagtail_modeltranslation/tests/tests.py
@@ -219,6 +219,16 @@ class WagtailModeltranslationTest(WagtailModeltranslationTestBase):
         self.assertEquals(child_block[0][0], 'text')
         self.assertIsInstance(child_block[0][1], CharBlock)
 
+        # Original and Default language StreamFields are required
+        self.assertFalse(models.StreamFieldPanelPage.body.field.blank)
+        self.assertTrue(models.StreamFieldPanelPage.body.field.stream_block.required)
+        self.assertFalse(models.StreamFieldPanelPage.body_de.field.blank)
+        self.assertTrue(models.StreamFieldPanelPage.body_de.field.stream_block.required)
+
+        # Translated StreamField is optional
+        self.assertTrue(models.StreamFieldPanelPage.body_en.field.blank)
+        self.assertFalse(models.StreamFieldPanelPage.body_en.field.stream_block.required)
+
     def check_multipanel_patching(self, panels):
         # There are three multifield panels, one for each of the available
         # children panels

--- a/wagtail_modeltranslation/tests/tests.py
+++ b/wagtail_modeltranslation/tests/tests.py
@@ -11,6 +11,10 @@ from django.test.client import RequestFactory
 from django.test.utils import override_settings
 from django.utils.translation import get_language, trans_real
 from modeltranslation import settings as mt_settings, translator
+try:
+    from wagtail import VERSION
+except ImportError:
+    VERSION = 1, 6, 3  # assume it's 1.6.3, the latest version without VERSION
 from .util import page_factory
 
 from wagtail_modeltranslation.tests.test_settings import TEST_SETTINGS
@@ -219,15 +223,16 @@ class WagtailModeltranslationTest(WagtailModeltranslationTestBase):
         self.assertEquals(child_block[0][0], 'text')
         self.assertIsInstance(child_block[0][1], CharBlock)
 
-        # Original and Default language StreamFields are required
-        self.assertFalse(models.StreamFieldPanelPage.body.field.blank)
-        self.assertTrue(models.StreamFieldPanelPage.body.field.stream_block.required)
-        self.assertFalse(models.StreamFieldPanelPage.body_de.field.blank)
-        self.assertTrue(models.StreamFieldPanelPage.body_de.field.stream_block.required)
+        if VERSION >= (1, 12):
+            # Original and Default language StreamFields are required
+            self.assertFalse(models.StreamFieldPanelPage.body.field.blank)
+            self.assertTrue(models.StreamFieldPanelPage.body.field.stream_block.required)
+            self.assertFalse(models.StreamFieldPanelPage.body_de.field.blank)
+            self.assertTrue(models.StreamFieldPanelPage.body_de.field.stream_block.required)
 
-        # Translated StreamField is optional
-        self.assertTrue(models.StreamFieldPanelPage.body_en.field.blank)
-        self.assertFalse(models.StreamFieldPanelPage.body_en.field.stream_block.required)
+            # Translated StreamField is optional
+            self.assertTrue(models.StreamFieldPanelPage.body_en.field.blank)
+            self.assertFalse(models.StreamFieldPanelPage.body_en.field.stream_block.required)
 
     def check_multipanel_patching(self, panels):
         # There are three multifield panels, one for each of the available


### PR DESCRIPTION
Fixes #170 

Ensure localized StreamFields remain optional as per [django-modeltranslation docs](http://django-modeltranslation.readthedocs.io/en/latest/registration.html?highlight=blank#required-fields) for Wagtail 1.12 and above.