### PR TITLE
Make slugurl_trans tag resilient to missing request

### DIFF
--- a/wagtail_modeltranslation/templatetags/wagtail_modeltranslation.py
+++ b/wagtail_modeltranslation/templatetags/wagtail_modeltranslation.py
@@ -9,8 +9,9 @@ from django.utils.translation import activate, get_language
 from six import iteritems
 
 from wagtail.wagtailcore.models import Page
-from modeltranslation import settings as mt_settings
+from wagtail.wagtailcore.templatetags.wagtailcore_tags import pageurl
 
+from modeltranslation import settings as mt_settings
 from modeltranslation.settings import DEFAULT_LANGUAGE
 
 from ..contextlib import use_language
@@ -80,11 +81,10 @@ def slugurl_trans(context, slug, language=None):
         page = Page.objects.filter(slug=slug).first()
 
     if page:
-        return page.relative_url(context['request'].site)
-    else:
-        return None
+        # call pageurl() instead of page.relative_url() here so we get the ``accepts_kwarg`` logic
+        return pageurl(context, page)
 
-        
+
 @register.tag('get_available_languages_wmt')
 def do_get_available_languages(unused_parser, token):
     """


### PR DESCRIPTION
Fixes #176.

* Remove call to `context['request']` to prevent KeyError;
* Replace it with call to `pageurl(context, page)` mimicking Wagtail's default behaviour (see [wagtailcore_tags.py#L37-L39](https://github.com/wagtail/wagtail/blob/master/wagtail/core/templatetags/wagtailcore_tags.py#L37-L39)), which does the exception handling.
* Does not include a failing test since the behaviour is mostly unchanged and mimics default wagtail code.