### PR TITLE
Travis: make clear which django version is used

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,8 @@ install:
   - if [[ $DB == mysql ]] && [[ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]]; then pip install -q mysql-python; elif [[ $DB == mysql ]] && [[ ${TRAVIS_PYTHON_VERSION:0:1} == "3" ]]; then pip install -q mysqlclient; fi
   - if [[ $DB == postgres ]]; then pip install -q psycopg2; fi
   - if [[ $TRAVIS_PYTHON_VERSION == '3.3' ]]; then pip install 'Django>=1.8,<1.9'; fi
-  - pip install -q $WAGTAIL
-  - pip install --process-dependency-links -e .
+  - pip install $WAGTAIL
+  - pip install -e .
 script:
+  - echo "DJANGO VERSION = `python -m django --version`"
   - ./runtests.py


### PR DESCRIPTION
I've noticed that the current travis console output is not very friendly in what regards figuring out Django's version. This PR helps with that.

Make clearer which django version is being tested:
- by printing it to the console;
- by outputting `pip install $WAGTAIL` output.
- Also remove `--process-dependency-links` as it's no longer needed.

Travis console example ([link](https://travis-ci.org/dmarcelino/wagtail-modeltranslation/jobs/347372362#L434)):

![image](https://user-images.githubusercontent.com/1280446/36802392-a4d87b9a-1cac-11e8-8983-7c390c5a9a93.png)