### PR TITLE
Check old_url_path is not None before len()

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,8 @@ setup(
         'wagtail_modeltranslation.makemigrations.management.commands'],
     package_data={'wagtail_modeltranslation': ['static/wagtail_modeltranslation/css/*.css',
                                                'static/wagtail_modeltranslation/js/*.js']},
-    install_requires=['wagtail(>=1.4)', 'django-modeltranslation(>=0.12.2)'],
+    install_requires=[
+        'wagtail(>=1.4,<2)', 'django-modeltranslation(>=0.12.2)'],
     download_url='https://github.com/infoportugal/wagtail-modeltranslation/archive/v0.8.tar.gz',
     classifiers=[
         'Programming Language :: Python',

--- a/wagtail_modeltranslation/patch_wagtailadmin.py
+++ b/wagtail_modeltranslation/patch_wagtailadmin.py
@@ -363,7 +363,7 @@ def _localized_update_descendant_url_paths(page, old_url_path, new_url_path, lan
             SET {localized_url_path}= CONCAT(%s, (SUBSTRING({localized_url_path}, 0, %s)))
             WHERE path LIKE %s AND id <> %s
         """.format(localized_url_path=localized_url_path)
-        cursor.execute(update_statement, [new_url_path, len(old_url_path) + 1, page.path + '%', page.id])
+        cursor.execute(update_statement, [new_url_path, (len(old_url_path) if old_url_path else 0) + 1, page.path + '%', page.id])
     else:
         (Page.objects
             .rewrite(False)
@@ -372,7 +372,7 @@ def _localized_update_descendant_url_paths(page, old_url_path, new_url_path, lan
             .exclude(pk=page.pk)
             .update(**{localized_url_path: Concat(
                 Value(new_url_path),
-                Substr(localized_url_path, len(old_url_path) + 1))}))
+                Substr(localized_url_path, (len(old_url_path) if old_url_path else 0) + 1))}))
 
 
 def _update_translation_descendant_url_paths(old_record, page):
@@ -381,8 +381,8 @@ def _update_translation_descendant_url_paths(old_record, page):
     default_localized_url_path = build_localized_fieldname('url_path', mt_settings.DEFAULT_LANGUAGE)
     for language in mt_settings.AVAILABLE_LANGUAGES:
         localized_url_path = build_localized_fieldname('url_path', language)
-        old_url_path = getattr(old_record, localized_url_path, '') or getattr(old_record, default_localized_url_path, '')
-        new_url_path = getattr(page, localized_url_path, '') or getattr(page, default_localized_url_path, '')
+        old_url_path = getattr(old_record, localized_url_path) or getattr(old_record, default_localized_url_path)
+        new_url_path = getattr(page, localized_url_path) or getattr(page, default_localized_url_path)
 
         if old_url_path == new_url_path:
             # nothing to do

--- a/wagtail_modeltranslation/patch_wagtailadmin.py
+++ b/wagtail_modeltranslation/patch_wagtailadmin.py
@@ -381,13 +381,13 @@ def _update_translation_descendant_url_paths(old_record, page):
     default_localized_url_path = build_localized_fieldname('url_path', mt_settings.DEFAULT_LANGUAGE)
     for language in mt_settings.AVAILABLE_LANGUAGES:
         localized_url_path = build_localized_fieldname('url_path', language)
-        old_url_path = getattr(old_record, localized_url_path) or getattr(old_record, default_localized_url_path)
-        new_url_path = getattr(page, localized_url_path) or getattr(page, default_localized_url_path)
+        old_url_path = getattr(old_record, localized_url_path, '') or getattr(old_record, default_localized_url_path, '')
+        new_url_path = getattr(page, localized_url_path, '' or getattr(page, default_localized_url_path, '')
 
         if old_url_path == new_url_path:
             # nothing to do
             continue
-
+        
         languages_changed.append(language)
         _localized_update_descendant_url_paths(page, old_url_path, new_url_path, language)
 

--- a/wagtail_modeltranslation/patch_wagtailadmin.py
+++ b/wagtail_modeltranslation/patch_wagtailadmin.py
@@ -382,7 +382,7 @@ def _update_translation_descendant_url_paths(old_record, page):
     for language in mt_settings.AVAILABLE_LANGUAGES:
         localized_url_path = build_localized_fieldname('url_path', language)
         old_url_path = getattr(old_record, localized_url_path, '') or getattr(old_record, default_localized_url_path, '')
-        new_url_path = getattr(page, localized_url_path, '' or getattr(page, default_localized_url_path, '')
+        new_url_path = getattr(page, localized_url_path, '') or getattr(page, default_localized_url_path, '')
 
         if old_url_path == new_url_path:
             # nothing to do

--- a/wagtail_modeltranslation/patch_wagtailadmin.py
+++ b/wagtail_modeltranslation/patch_wagtailadmin.py
@@ -387,7 +387,7 @@ def _update_translation_descendant_url_paths(old_record, page):
         if old_url_path == new_url_path:
             # nothing to do
             continue
-        
+
         languages_changed.append(language)
         _localized_update_descendant_url_paths(page, old_url_path, new_url_path, language)
 


### PR DESCRIPTION
We were seeing errors publishing pages that were created before model translations were enabled because the old translated slugs are None instead of `''` so `len()` is angry.

cc: @jflitton