### PR TITLE
Add support for Wagtail 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,17 +2,20 @@ language: python
 python:
   - "3.6"
 env:
-  - WAGTAIL="wagtail>=1.13,<1.14" DB=sqlite
+  - WAGTAIL="wagtail>=2.0,<2.1" DB=sqlite
 matrix:
   include:
   # Latest Wagtail version
-  - env: WAGTAIL="wagtail>=1.13,<1.14" DB=sqlite
-  - env: WAGTAIL="wagtail>=1.13,<1.14" DB=postgres
-  - env: WAGTAIL="wagtail>=1.13,<1.14" DB=mysql
+  - env: WAGTAIL="wagtail>=2.0,<2.1" DB=sqlite
+  - env: WAGTAIL="wagtail>=2.0,<2.1" DB=postgres
+  - env: WAGTAIL="wagtail>=2.0,<2.1" DB=mysql
   - python: "3.5"
   - python: "3.4"
-  - python: "2.7"
   # Past Wagtail versions
+  - python: "3.6"
+    env: WAGTAIL="wagtail>=1.13,<1.14"
+  - python: "2.7"  # Wagtail 1.13 was the latest tested against 2.7
+    env: WAGTAIL="wagtail>=1.13,<1.14"
   - python: "3.6"
     env: WAGTAIL="wagtail>=1.12,<1.13"
   - python: "3.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,8 @@ install:
   - if [[ $DB == mysql ]] && [[ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]]; then pip install -q mysql-python; elif [[ $DB == mysql ]] && [[ ${TRAVIS_PYTHON_VERSION:0:1} == "3" ]]; then pip install -q mysqlclient; fi
   - if [[ $DB == postgres ]]; then pip install -q psycopg2; fi
   - if [[ $TRAVIS_PYTHON_VERSION == '3.3' ]]; then pip install 'Django>=1.8,<1.9'; fi
-  - pip install -q $WAGTAIL
-  - pip install --process-dependency-links -e .
+  - pip install $WAGTAIL
+  - pip install -e .
 script:
+  - echo "DJANGO VERSION = `python -m django --version`"
   - ./runtests.py

--- a/runtests.py
+++ b/runtests.py
@@ -5,6 +5,10 @@ import sys
 import django
 from django.conf import settings
 from django.core.management import call_command
+try:
+    from wagtail import VERSION
+except ImportError:
+    VERSION = 1, 6, 3  # assume it's 1.6.3, the latest version without VERSION
 
 
 def runtests():
@@ -32,7 +36,7 @@ def runtests():
 
         # Configure test environment
         import wagtail
-        if wagtail.VERSION[0] < 2:
+        if VERSION[0] < 2:
             WAGTAIL_MODULES = [
                 'wagtail.wagtailcore',
                 'wagtail.wagtailadmin',

--- a/runtests.py
+++ b/runtests.py
@@ -31,14 +31,9 @@ def runtests():
             })
 
         # Configure test environment
-        settings.configure(
-            DATABASES=DATABASES,
-            INSTALLED_APPS=(
-                'django.contrib.contenttypes',
-                'django.contrib.auth',
-                'taggit',
-                'rest_framework',
-
+        import wagtail
+        if wagtail.VERSION[0] < 2:
+            WAGTAIL_MODULES = [
                 'wagtail.wagtailcore',
                 'wagtail.wagtailadmin',
                 'wagtail.wagtaildocs',
@@ -52,13 +47,41 @@ def runtests():
                 'wagtail.wagtailsites',
                 'wagtail.contrib.settings',
                 'wagtail.contrib.wagtailapi',
+            ]
+            WAGTAIL_CORE = 'wagtail.wagtailcore'
+        else:
+            WAGTAIL_MODULES = [
+                'wagtail.core',
+                'wagtail.admin',
+                'wagtail.documents',
+                'wagtail.snippets',
+                'wagtail.users',
+                'wagtail.images',
+                'wagtail.embeds',
+                'wagtail.search',
+                'wagtail.contrib.redirects',
+                'wagtail.contrib.forms',
+                'wagtail.sites',
+                'wagtail.contrib.settings',
+                'wagtail.api'
+            ]
+            WAGTAIL_CORE = 'wagtail.core'
 
+            
+        settings.configure(
+            DATABASES=DATABASES,
+            INSTALLED_APPS=[
+                'django.contrib.contenttypes',
+                'django.contrib.auth',
+                'taggit',
+                'rest_framework'] +
+                WAGTAIL_MODULES + [
                 'wagtail_modeltranslation.makemigrations',
                 'wagtail_modeltranslation',
-            ),
+            ],
             # remove wagtailcore from serialization as translation columns have not been created at this point
             # (which causes OperationalError: no such column)
-            TEST_NON_SERIALIZED_APPS=['wagtail.wagtailcore'],
+            TEST_NON_SERIALIZED_APPS=[WAGTAIL_CORE],
             ROOT_URLCONF=None,  # tests override urlconf, but it still needs to be defined
             LANGUAGES=(
                 ('en', 'English'),

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,8 @@ setup(
         'wagtail_modeltranslation.makemigrations.management.commands'],
     package_data={'wagtail_modeltranslation': ['static/wagtail_modeltranslation/css/*.css',
                                                'static/wagtail_modeltranslation/js/*.js']},
-    install_requires=['wagtail(>=1.4)', 'django-modeltranslation(>=0.12.2)'],
+    install_requires=[
+        'wagtail(>=1.4,<2)', 'django-modeltranslation(>=0.12.2)'],
     download_url='https://github.com/infoportugal/wagtail-modeltranslation/archive/v0.8.tar.gz',
     classifiers=[
         'Programming Language :: Python',

--- a/wagtail_modeltranslation/management/commands/set_translation_url_paths.py
+++ b/wagtail_modeltranslation/management/commands/set_translation_url_paths.py
@@ -3,8 +3,11 @@
 from django.core.management.base import BaseCommand
 from modeltranslation import settings as mt_settings
 from modeltranslation.utils import build_localized_fieldname
-from wagtail.wagtailcore.models import Page
 from wagtail_modeltranslation.contextlib import use_language
+try:
+    from wagtail.core.models import Page
+except ImportError:
+    from wagtail.wagtailcore.models import Page
 
 
 class Command(BaseCommand):

--- a/wagtail_modeltranslation/management/commands/sync_page_translation_fields.py
+++ b/wagtail_modeltranslation/management/commands/sync_page_translation_fields.py
@@ -1,6 +1,9 @@
 from modeltranslation.management.commands.sync_translation_fields import Command as SyncTranslationsFieldsCommand
 from modeltranslation.translator import translator
-from wagtail.wagtailcore.models import Page
+try:
+    from wagtail.core.models import Page
+except ImportError:
+    from wagtail.wagtailcore.models import Page
 
 
 old_get_registered_models = translator.get_registered_models

--- a/wagtail_modeltranslation/patch_wagtailadmin.py
+++ b/wagtail_modeltranslation/patch_wagtailadmin.py
@@ -15,19 +15,30 @@ from modeltranslation.translator import translator, NotRegistered
 from modeltranslation.utils import build_localized_fieldname, get_language
 from wagtail.contrib.settings.models import BaseSetting
 from wagtail.contrib.settings.views import get_setting_edit_handler
-from wagtail.contrib.wagtailroutablepage.models import RoutablePageMixin
-from wagtail.wagtailadmin.edit_handlers import FieldPanel, \
-    MultiFieldPanel, FieldRowPanel, InlinePanel, StreamFieldPanel, RichTextFieldPanel
-from wagtail.wagtailcore.models import Page
-from wagtail.wagtailcore.fields import StreamField, StreamValue
-from wagtail.wagtailcore.url_routing import RouteResult
-from wagtail.wagtailimages.edit_handlers import ImageChooserPanel
-from wagtail.wagtailsearch.index import SearchField
-from wagtail.wagtailsnippets.models import get_snippet_models
-from wagtail.wagtailsnippets.views.snippets import SNIPPET_EDIT_HANDLERS
-
 from wagtail_modeltranslation.settings import CUSTOM_SIMPLE_PANELS, CUSTOM_COMPOSED_PANELS
 from wagtail_modeltranslation.utils import compare_class_tree_depth
+try:
+    from wagtail.contrib.routable_page.models import RoutablePageMixin
+    from wagtail.admin.edit_handlers import FieldPanel, \
+        MultiFieldPanel, FieldRowPanel, InlinePanel, StreamFieldPanel, RichTextFieldPanel
+    from wagtail.core.models import Page
+    from wagtail.core.fields import StreamField, StreamValue
+    from wagtail.core.url_routing import RouteResult
+    from wagtail.images.edit_handlers import ImageChooserPanel
+    from wagtail.search.index import SearchField
+    from wagtail.snippets.models import get_snippet_models
+    from wagtail.snippets.views.snippets import SNIPPET_EDIT_HANDLERS
+except ImportError:
+    from wagtail.contrib.wagtailroutablepage.models import RoutablePageMixin
+    from wagtail.wagtailadmin.edit_handlers import FieldPanel, \
+        MultiFieldPanel, FieldRowPanel, InlinePanel, StreamFieldPanel, RichTextFieldPanel
+    from wagtail.wagtailcore.models import Page
+    from wagtail.wagtailcore.fields import StreamField, StreamValue
+    from wagtail.wagtailcore.url_routing import RouteResult
+    from wagtail.wagtailimages.edit_handlers import ImageChooserPanel
+    from wagtail.wagtailsearch.index import SearchField
+    from wagtail.wagtailsnippets.models import get_snippet_models
+    from wagtail.wagtailsnippets.views.snippets import SNIPPET_EDIT_HANDLERS
 
 logger = logging.getLogger('wagtail.core')
 

--- a/wagtail_modeltranslation/templatetags/wagtail_modeltranslation.py
+++ b/wagtail_modeltranslation/templatetags/wagtail_modeltranslation.py
@@ -3,8 +3,12 @@
 import re
 
 from django import template
-from django.core.urlresolvers import resolve
 from django.utils.translation import activate, get_language
+
+try:
+    from django.core.urlresolvers import resolve
+except ImportError:
+    from django.urls import resolve
 
 from six import iteritems
 

--- a/wagtail_modeltranslation/templatetags/wagtail_modeltranslation.py
+++ b/wagtail_modeltranslation/templatetags/wagtail_modeltranslation.py
@@ -8,8 +8,12 @@ from django.utils.translation import activate, get_language
 
 from six import iteritems
 
-from wagtail.wagtailcore.models import Page
-from wagtail.wagtailcore.templatetags.wagtailcore_tags import pageurl
+try:
+    from wagtail.core.models import Page
+    from wagtail.core.templatetags.wagtailcore_tags import pageurl
+except ImportError:
+    from wagtail.wagtailcore.models import Page
+    from wagtail.wagtailcore.templatetags.wagtailcore_tags import pageurl
 
 from modeltranslation import settings as mt_settings
 from modeltranslation.settings import DEFAULT_LANGUAGE

--- a/wagtail_modeltranslation/tests/models.py
+++ b/wagtail_modeltranslation/tests/models.py
@@ -2,14 +2,25 @@
 from django.db import models
 from django.http import HttpResponse
 from modelcluster.fields import ParentalKey
-from wagtail.contrib.wagtailroutablepage.models import RoutablePageMixin, route
-from wagtail.wagtailadmin.edit_handlers import FieldPanel, MultiFieldPanel, FieldRowPanel, InlinePanel, StreamFieldPanel
-from wagtail.wagtailcore import blocks
-from wagtail.wagtailcore.fields import StreamField
-from wagtail.wagtailcore.models import Page as WagtailPage
-from wagtail.wagtailimages.edit_handlers import ImageChooserPanel
-from wagtail.wagtailsearch import index
-from wagtail.wagtailsnippets.models import register_snippet
+try:
+    from wagtail.contrib.routable_page.models import RoutablePageMixin, route
+    from wagtail.admin.edit_handlers import FieldPanel, MultiFieldPanel, FieldRowPanel, InlinePanel, StreamFieldPanel
+    from wagtail.core import blocks
+    from wagtail.core.fields import StreamField
+    from wagtail.core.models import Page as WagtailPage
+    from wagtail.images.edit_handlers import ImageChooserPanel
+    from wagtail.search import index
+    from wagtail.snippets.models import register_snippet
+except ImportError:
+    from wagtail.contrib.wagtailroutablepage.models import RoutablePageMixin, route
+    from wagtail.wagtailadmin.edit_handlers import FieldPanel, MultiFieldPanel, FieldRowPanel, InlinePanel, \
+        StreamFieldPanel
+    from wagtail.wagtailcore import blocks
+    from wagtail.wagtailcore.fields import StreamField
+    from wagtail.wagtailcore.models import Page as WagtailPage
+    from wagtail.wagtailimages.edit_handlers import ImageChooserPanel
+    from wagtail.wagtailsearch import index
+    from wagtail.wagtailsnippets.models import register_snippet
 
 
 # Wagtail Models

--- a/wagtail_modeltranslation/tests/tests.py
+++ b/wagtail_modeltranslation/tests/tests.py
@@ -140,7 +140,10 @@ class WagtailModeltranslationTest(WagtailModeltranslationTestBase):
         super(WagtailModeltranslationTest, cls).setUpClass()
 
         # Delete the default wagtail pages from db
-        from wagtail.core.models import Page
+        try:
+            from wagtail.core.models import Page
+        except ImportError:
+            from wagtail.wagtailcore.models import Page
         Page.objects.delete()
 
     def test_page_fields(self):

--- a/wagtail_modeltranslation/tests/tests.py
+++ b/wagtail_modeltranslation/tests/tests.py
@@ -59,12 +59,16 @@ class WagtailModeltranslationTransactionTestBase(TransactionTestCase):
 
                 # reload the translation module to register the Page model
                 # and also edit_handlers so any patches made to Page are reapplied
-                from wagtail_modeltranslation import translation as wag_translation
-                from wagtail.wagtailadmin import edit_handlers
                 import sys
                 del cls.cache.all_models['wagtailcore']
                 sys.modules.pop('wagtail_modeltranslation.translation.pagetr', None)
-                sys.modules.pop('wagtail.wagtailcore.models', None)
+                from wagtail_modeltranslation import translation as wag_translation
+                try:
+                    from wagtail.admin import edit_handlers
+                    sys.modules.pop('wagtail.core.models', None)
+                except ImportError:
+                    from wagtail.wagtailadmin import edit_handlers
+                    sys.modules.pop('wagtail.wagtailcore.models', None)
                 imp.reload(wag_translation)
                 imp.reload(edit_handlers)  # so Page can be repatched by edit_handlers
                 wagtailcore_args = []
@@ -136,7 +140,7 @@ class WagtailModeltranslationTest(WagtailModeltranslationTestBase):
         super(WagtailModeltranslationTest, cls).setUpClass()
 
         # Delete the default wagtail pages from db
-        from wagtail.wagtailcore.models import Page
+        from wagtail.core.models import Page
         Page.objects.delete()
 
     def test_page_fields(self):
@@ -170,7 +174,7 @@ class WagtailModeltranslationTest(WagtailModeltranslationTestBase):
         self.assertEquals(len(panels), 2)
 
         # Validate if the created panels are instances of FieldPanel
-        from wagtail.wagtailadmin.edit_handlers import FieldPanel
+        from wagtail.admin.edit_handlers import FieldPanel
         self.assertIsInstance(panels[0], FieldPanel)
         self.assertIsInstance(panels[1], FieldPanel)
 
@@ -182,7 +186,7 @@ class WagtailModeltranslationTest(WagtailModeltranslationTestBase):
         # Check if there is one panel per language
         self.assertEquals(len(panels), 2)
 
-        from wagtail.wagtailimages.edit_handlers import ImageChooserPanel
+        from wagtail.images.edit_handlers import ImageChooserPanel
         self.assertIsInstance(panels[0], ImageChooserPanel)
         self.assertIsInstance(panels[1], ImageChooserPanel)
 
@@ -194,7 +198,7 @@ class WagtailModeltranslationTest(WagtailModeltranslationTestBase):
         # Check if the fieldrowpanel still exists
         self.assertEqual(len(panels), 1)
 
-        from wagtail.wagtailadmin.edit_handlers import FieldRowPanel
+        from wagtail.admin.edit_handlers import FieldRowPanel
         self.assertIsInstance(panels[0], FieldRowPanel)
 
         # Check if the children were correctly patched using the fieldpanel test
@@ -206,7 +210,7 @@ class WagtailModeltranslationTest(WagtailModeltranslationTestBase):
         # Check if there is one panel per language
         self.assertEquals(len(panels), 2)
 
-        from wagtail.wagtailadmin.edit_handlers import StreamFieldPanel
+        from wagtail.admin.edit_handlers import StreamFieldPanel
         self.assertIsInstance(panels[0], StreamFieldPanel)
         self.assertIsInstance(panels[1], StreamFieldPanel)
 
@@ -219,7 +223,7 @@ class WagtailModeltranslationTest(WagtailModeltranslationTestBase):
 
         self.assertEquals(len(child_block), 1)
 
-        from wagtail.wagtailcore.blocks import CharBlock
+        from wagtail.core.blocks import CharBlock
         self.assertEquals(child_block[0][0], 'text')
         self.assertIsInstance(child_block[0][1], CharBlock)
 
@@ -239,7 +243,7 @@ class WagtailModeltranslationTest(WagtailModeltranslationTestBase):
         # children panels
         self.assertEquals(len(panels), 3)
 
-        from wagtail.wagtailadmin.edit_handlers import MultiFieldPanel
+        from wagtail.admin.edit_handlers import MultiFieldPanel
         self.assertIsInstance(panels[0], MultiFieldPanel)
         self.assertIsInstance(panels[1], MultiFieldPanel)
         self.assertIsInstance(panels[2], MultiFieldPanel)
@@ -324,7 +328,7 @@ class WagtailModeltranslationTest(WagtailModeltranslationTestBase):
         In this test we use the InlinePanelSnippet model because it has all the possible "patchable" fields
         so if the created form has all fields the the form was correctly patched
         """
-        from wagtail.wagtailsnippets.views.snippets import get_snippet_edit_handler
+        from wagtail.snippets.views.snippets import get_snippet_edit_handler
         snippet_edit_handler = get_snippet_edit_handler(models.InlinePanelSnippet)
 
         form = snippet_edit_handler.get_form_class(models.InlinePanelSnippet)
@@ -343,7 +347,7 @@ class WagtailModeltranslationTest(WagtailModeltranslationTestBase):
             self.assertItemsEqual(inline_model_fields, related_formset_form.base_fields.keys())
 
     def test_duplicate_slug(self):
-        from wagtail.wagtailcore.models import Site
+        from wagtail.core.models import Site
         # Create a test Site with a root page
         root = models.TestRootPage(title='title', depth=1, path='0001', slug_en='slug_en', slug_de='slug_de')
         root.save()
@@ -406,7 +410,7 @@ class WagtailModeltranslationTest(WagtailModeltranslationTestBase):
         self.assertEqual(slugurl_trans(context, 'child-slugurl-en', 'en'), '/en/child-slugurl-en/')
 
     def test_relative_url(self):
-        from wagtail.wagtailcore.models import Site
+        from wagtail.core.models import Site
         # Create a test Site with a root page
         root = models.TestRootPage(title='title slugurl', depth=1, path='0004',
                                    slug_en='title_slugurl_en', slug_de='title_slugurl_de')
@@ -481,7 +485,7 @@ class WagtailModeltranslationTest(WagtailModeltranslationTestBase):
         Assert translation URL Paths are correctly set in page and descendants for a slug change and
         page move operations
         """
-        from wagtail.wagtailcore.models import Site
+        from wagtail.core.models import Site
         # Create a test Site with a root page
         root = models.TestRootPage.objects.create(title='url paths', depth=1, path='0006', slug='url-path-slug')
 

--- a/wagtail_modeltranslation/tests/tests.py
+++ b/wagtail_modeltranslation/tests/tests.py
@@ -298,7 +298,10 @@ class WagtailModeltranslationTest(WagtailModeltranslationTestBase):
 
         page_edit_handler = models.InlinePanelPage.get_edit_handler()
 
-        form = page_edit_handler.get_form_class(models.InlinePanelPage)
+        if VERSION[0] < 2:
+            form = page_edit_handler.get_form_class(models.InlinePanelPage)
+        else:
+            form = page_edit_handler.get_form_class()
 
         page_base_fields = ['slug_de', 'slug_en', 'seo_title_de', 'seo_title_en', 'search_description_de',
                             'search_description_en', u'show_in_menus', u'go_live_at', u'expire_at']
@@ -331,7 +334,10 @@ class WagtailModeltranslationTest(WagtailModeltranslationTestBase):
         from wagtail.snippets.views.snippets import get_snippet_edit_handler
         snippet_edit_handler = get_snippet_edit_handler(models.InlinePanelSnippet)
 
-        form = snippet_edit_handler.get_form_class(models.InlinePanelSnippet)
+        if VERSION[0] < 2:
+            form = snippet_edit_handler.get_form_class(models.InlinePanelSnippet)
+        else:
+            form = snippet_edit_handler.get_form_class()
 
         inline_model_fields = ['field_name_de', 'field_name_en', 'image_chooser_de', 'image_chooser_en',
                                'fieldrow_name_de', 'fieldrow_name_en', 'name_de', 'name_en', 'image_de', 'image_en',

--- a/wagtail_modeltranslation/tests/tests.py
+++ b/wagtail_modeltranslation/tests/tests.py
@@ -177,7 +177,11 @@ class WagtailModeltranslationTest(WagtailModeltranslationTestBase):
         self.assertEquals(len(panels), 2)
 
         # Validate if the created panels are instances of FieldPanel
-        from wagtail.admin.edit_handlers import FieldPanel
+        try:
+            from wagtail.admin.edit_handlers import FieldPanel
+        except ImportError:
+            from wagtail.wagtailadmin.edit_handlers import FieldPanel
+
         self.assertIsInstance(panels[0], FieldPanel)
         self.assertIsInstance(panels[1], FieldPanel)
 
@@ -189,7 +193,10 @@ class WagtailModeltranslationTest(WagtailModeltranslationTestBase):
         # Check if there is one panel per language
         self.assertEquals(len(panels), 2)
 
-        from wagtail.images.edit_handlers import ImageChooserPanel
+        try:
+            from wagtail.images.edit_handlers import ImageChooserPanel
+        except ImportError:
+            from wagtail.wagtailimages.edit_handlers import ImageChooserPanel
         self.assertIsInstance(panels[0], ImageChooserPanel)
         self.assertIsInstance(panels[1], ImageChooserPanel)
 
@@ -201,7 +208,10 @@ class WagtailModeltranslationTest(WagtailModeltranslationTestBase):
         # Check if the fieldrowpanel still exists
         self.assertEqual(len(panels), 1)
 
-        from wagtail.admin.edit_handlers import FieldRowPanel
+        try:
+            from wagtail.admin.edit_handlers import FieldRowPanel
+        except ImportError:
+            from wagtail.wagtailadmin.edit_handlers import FieldRowPanel
         self.assertIsInstance(panels[0], FieldRowPanel)
 
         # Check if the children were correctly patched using the fieldpanel test
@@ -213,7 +223,10 @@ class WagtailModeltranslationTest(WagtailModeltranslationTestBase):
         # Check if there is one panel per language
         self.assertEquals(len(panels), 2)
 
-        from wagtail.admin.edit_handlers import StreamFieldPanel
+        try:
+            from wagtail.admin.edit_handlers import StreamFieldPanel
+        except ImportError:
+            from wagtail.wagtailadmin.edit_handlers import StreamFieldPanel
         self.assertIsInstance(panels[0], StreamFieldPanel)
         self.assertIsInstance(panels[1], StreamFieldPanel)
 
@@ -226,7 +239,10 @@ class WagtailModeltranslationTest(WagtailModeltranslationTestBase):
 
         self.assertEquals(len(child_block), 1)
 
-        from wagtail.core.blocks import CharBlock
+        try:
+            from wagtail.core.blocks import CharBlock
+        except ImportError:
+            from wagtail.wagtailcore.blocks import CharBlock
         self.assertEquals(child_block[0][0], 'text')
         self.assertIsInstance(child_block[0][1], CharBlock)
 
@@ -246,7 +262,10 @@ class WagtailModeltranslationTest(WagtailModeltranslationTestBase):
         # children panels
         self.assertEquals(len(panels), 3)
 
-        from wagtail.admin.edit_handlers import MultiFieldPanel
+        try:
+            from wagtail.admin.edit_handlers import MultiFieldPanel
+        except ImportError:
+            from wagtail.wagtailadmin.edit_handlers import MultiFieldPanel
         self.assertIsInstance(panels[0], MultiFieldPanel)
         self.assertIsInstance(panels[1], MultiFieldPanel)
         self.assertIsInstance(panels[2], MultiFieldPanel)
@@ -334,7 +353,10 @@ class WagtailModeltranslationTest(WagtailModeltranslationTestBase):
         In this test we use the InlinePanelSnippet model because it has all the possible "patchable" fields
         so if the created form has all fields the the form was correctly patched
         """
-        from wagtail.snippets.views.snippets import get_snippet_edit_handler
+        try:
+            from wagtail.snippets.views.snippets import get_snippet_edit_handler
+        except ImportError:
+            from wagtail.wagtailsnippets.views.snippets import get_snippet_edit_handler
         snippet_edit_handler = get_snippet_edit_handler(models.InlinePanelSnippet)
 
         if VERSION[0] < 2:
@@ -356,7 +378,10 @@ class WagtailModeltranslationTest(WagtailModeltranslationTestBase):
             self.assertItemsEqual(inline_model_fields, related_formset_form.base_fields.keys())
 
     def test_duplicate_slug(self):
-        from wagtail.core.models import Site
+        try:
+            from wagtail.core.models import Site
+        except ImportError:
+            from wagtail.wagtailcore.models import Site
         # Create a test Site with a root page
         root = models.TestRootPage(title='title', depth=1, path='0001', slug_en='slug_en', slug_de='slug_de')
         root.save()
@@ -419,7 +444,10 @@ class WagtailModeltranslationTest(WagtailModeltranslationTestBase):
         self.assertEqual(slugurl_trans(context, 'child-slugurl-en', 'en'), '/en/child-slugurl-en/')
 
     def test_relative_url(self):
-        from wagtail.core.models import Site
+        try:
+            from wagtail.core.models import Site
+        except ImportError:
+            from wagtail.wagtailcore.models import Site
         # Create a test Site with a root page
         root = models.TestRootPage(title='title slugurl', depth=1, path='0004',
                                    slug_en='title_slugurl_en', slug_de='title_slugurl_de')
@@ -494,7 +522,10 @@ class WagtailModeltranslationTest(WagtailModeltranslationTestBase):
         Assert translation URL Paths are correctly set in page and descendants for a slug change and
         page move operations
         """
-        from wagtail.core.models import Site
+        try:
+            from wagtail.core.models import Site
+        except ImportError:
+            from wagtail.wagtailcore.models import Site
         # Create a test Site with a root page
         root = models.TestRootPage.objects.create(title='url paths', depth=1, path='0006', slug='url-path-slug')
 

--- a/wagtail_modeltranslation/tests/urls.py
+++ b/wagtail_modeltranslation/tests/urls.py
@@ -2,7 +2,10 @@
 from django.conf.urls import include, url
 from django.conf.urls.i18n import i18n_patterns
 from django.views.i18n import set_language
-from wagtail.wagtailcore import urls as wagtail_urls
+try:
+    from wagtail.core import urls as wagtail_urls
+except ImportError:
+    from wagtail.wagtailcore import urls as wagtail_urls
 
 urlpatterns = [
     url(r'^set_language/$', set_language, {},

--- a/wagtail_modeltranslation/tests/util.py
+++ b/wagtail_modeltranslation/tests/util.py
@@ -33,7 +33,10 @@ class PageFactory(object):
         if not nodes:
             return None
 
-        from wagtail.wagtailcore.models import Site
+        try:
+            from wagtail.core.models import Site
+        except ImportError:
+            from wagtail.wagtailcore.models import Site
         root_node = self.create_instance(nodes)
         site = Site.objects.create(root_page=root_node)
         return site

--- a/wagtail_modeltranslation/translation.py
+++ b/wagtail_modeltranslation/translation.py
@@ -2,8 +2,10 @@
 
 from modeltranslation.decorators import register
 from modeltranslation.translator import TranslationOptions
-from wagtail.wagtailcore.models import Page
-
+try:
+    from wagtail.core.models import Page
+except ImportError:
+    from wagtail.wagtailcore.models import Page
 
 @register(Page)
 class PageTR(TranslationOptions):

--- a/wagtail_modeltranslation/wagtail_hooks.py
+++ b/wagtail_modeltranslation/wagtail_hooks.py
@@ -9,9 +9,14 @@ from django.http import QueryDict
 from django.utils.html import format_html, format_html_join, escape
 from django.views.decorators.csrf import csrf_exempt
 from six import iteritems
-from wagtail.wagtailcore import hooks
-from wagtail.wagtailcore.models import Page
-from wagtail.wagtailcore.rich_text import PageLinkHandler
+try:
+    from wagtail.core import hooks
+    from wagtail.core.models import Page
+    from wagtail.core.rich_text import PageLinkHandler
+except ImportError:
+    from wagtail.wagtailcore import hooks
+    from wagtail.wagtailcore.models import Page
+    from wagtail.wagtailcore.rich_text import PageLinkHandler
 
 
 @hooks.register('insert_editor_js')

--- a/wagtail_modeltranslation/wagtail_hooks.py
+++ b/wagtail_modeltranslation/wagtail_hooks.py
@@ -12,7 +12,7 @@ from six import iteritems
 try:
     from wagtail.core import hooks
     from wagtail.core.models import Page
-    from wagtail.core.rich_text import PageLinkHandler
+    from wagtail.core.rich_text.pages import PageLinkHandler
 except ImportError:
     from wagtail.wagtailcore import hooks
     from wagtail.wagtailcore.models import Page


### PR DESCRIPTION
This PR replaces PR #180 and fixes #169.

Also, this PR was branched from PR #181, so please merge that one first.

The changes here are essentially cherry picks from PR #180, I've picked the changes related to Wagtail2 and ignored any Django 2 specific changes. Those should be handled on a separate PR and can only be done after `django-modeltranslation` releases a new version (see deschler/django-modeltranslation#436).

Summary of changes:

- Ensure wagtail version < 2 (credit to @Jason-Abbott)
- Wagtail 2 support with backwards compatibility (credit to @stuaxo)
- Update travis.yml to test wagtail 2