### PR TITLE
Force django<2 while allowing Wagtail 2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,8 +30,7 @@ setup(
         'wagtail_modeltranslation.migrate.management.commands'],
     package_data={'wagtail_modeltranslation': ['static/wagtail_modeltranslation/css/*.css',
                                                'static/wagtail_modeltranslation/js/*.js']},
-    install_requires=[
-        'wagtail(>=1.4,<2)', 'django-modeltranslation(>=0.12.2)'],
+    install_requires=['Django(<2.0)', 'wagtail(>=1.4)', 'django-modeltranslation(>=0.12.2)'],
     download_url='https://github.com/infoportugal/wagtail-modeltranslation/archive/v0.8.tar.gz',
     classifiers=[
         'Programming Language :: Python',


### PR DESCRIPTION
As @stuaxo pointed out in https://github.com/infoportugal/wagtail-modeltranslation/pull/185#issuecomment-375334755, PR #185 wrongfully set `wagtail<2` instead of `Django<2`. This means that `0.8.1` doesn't allow for Wagtail2 to be used and doesn't enforce Django to be set below v2.

This PR fixes things by changing `setup.py` to `install_requires=['Django(<2.0)', 'wagtail(>=1.4)', 'django-modeltranslation(>=0.12.2)'],`

@DiogoMarques29, @tiagofmc please review and consider making a new release so people can use `wagtail-modeltranslation` with `wagtail` 2.