### PR TITLE
_get_site_root_paths: clear cache when changing languages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,9 @@ _build
 # GitEye / Eclipse project file
 /.project
 
+# PyCharm
+/.idea
+
 # vim
 *~
 *.swp

--- a/wagtail_modeltranslation/patch_wagtailadmin.py
+++ b/wagtail_modeltranslation/patch_wagtailadmin.py
@@ -5,20 +5,18 @@ import types
 
 from django.core.cache import cache
 from django.core.exceptions import ValidationError
+from django.core.urlresolvers import reverse
 from django.db import transaction, connection
 from django.db.models import Q, Value
 from django.db.models.functions import Concat, Substr
 from django.http import Http404
 from django.utils.translation import trans_real
 from django.utils.translation import ugettext_lazy as _
-from functools import wraps
 from modeltranslation import settings as mt_settings
 from modeltranslation.translator import translator, NotRegistered
 from modeltranslation.utils import build_localized_fieldname, get_language
 from wagtail.contrib.settings.models import BaseSetting
 from wagtail.contrib.settings.views import get_setting_edit_handler
-from wagtail_modeltranslation.settings import CUSTOM_SIMPLE_PANELS, CUSTOM_COMPOSED_PANELS
-from wagtail_modeltranslation.utils import compare_class_tree_depth
 try:
     from wagtail.contrib.routable_page.models import RoutablePageMixin
     from wagtail.admin.edit_handlers import FieldPanel, \
@@ -41,6 +39,15 @@ except ImportError:
     from wagtail.wagtailsearch.index import SearchField
     from wagtail.wagtailsnippets.models import get_snippet_models
     from wagtail.wagtailsnippets.views.snippets import SNIPPET_EDIT_HANDLERS
+try:
+    from wagtail.core.utils import WAGTAIL_APPEND_SLASH
+except ImportError:
+    try:
+        from wagtail.wagtailcore.utils import WAGTAIL_APPEND_SLASH
+    except ImportError:
+        WAGTAIL_APPEND_SLASH = True  # Wagtail<1.5
+from wagtail_modeltranslation.settings import CUSTOM_SIMPLE_PANELS, CUSTOM_COMPOSED_PANELS
+from wagtail_modeltranslation.utils import compare_class_tree_depth
 
 logger = logging.getLogger('wagtail.core')
 
@@ -114,11 +121,10 @@ class WagtailTranslator(object):
         # OVERRIDE PAGE METHODS
         model.set_url_path = _new_set_url_path
         model.route = _new_route
-        try:
-            model._get_site_root_paths = _get_site_root_paths_decorator(model._get_site_root_paths)
-        except AttributeError:
-            model.get_url_parts = _get_site_root_paths_decorator(model.get_url_parts)
         model._update_descendant_url_paths = _new_update_descendant_url_paths
+        if not hasattr(model, '_get_site_root_paths'):
+            model.get_url_parts = _new_get_url_parts  # Wagtail<1.11
+        model._get_site_root_paths = _new_get_site_root_paths
         _patch_clean(model)
 
         if not model.save.__name__.startswith('localized'):
@@ -392,6 +398,57 @@ def _localized_update_descendant_url_paths(page, old_url_path, new_url_path, lan
                 Substr(localized_url_path, len(old_url_path) + 1))}))
 
 
+def _localized_site_get_site_root_paths():
+    """
+    Localized version of ``Site.get_site_root_paths()``
+    """
+    current_language = get_language()
+    cache_key = 'wagtail_site_root_paths_{}'.format(current_language)
+    result = cache.get(cache_key)
+
+    if result is None:
+        result = [
+            (site.id, site.root_page.url_path, site.root_url)
+            for site in Site.objects.select_related('root_page').order_by('-root_page__url_path')
+        ]
+        cache.set(cache_key, result, 3600)
+
+    return result
+
+
+def _new_get_site_root_paths(self, request=None):
+    """
+    Return localized site_root_paths, using the cached copy on the
+    request object if available and if language is the same.
+    """
+    # if we have a request, use that to cache site_root_paths; otherwise, use self
+    current_language = get_language()
+    cache_object = request if request else self
+    if not hasattr(cache_object, '_wagtail_cached_site_root_paths_language') or \
+            cache_object._wagtail_cached_site_root_paths_language != current_language:
+        cache_object._wagtail_cached_site_root_paths_language = current_language
+        cache_object._wagtail_cached_site_root_paths = _localized_site_get_site_root_paths()
+
+    return cache_object._wagtail_cached_site_root_paths
+
+
+def _new_get_url_parts(self, request=None):
+    """
+    For Wagtail<1.11 ``Page.get_url_parts()`` is patched so it uses ``self._get_site_root_paths(request)``
+    """
+    for (site_id, root_path, root_url) in self._get_site_root_paths(request):
+        if self.url_path.startswith(root_path):
+            page_path = reverse('wagtail_serve', args=(self.url_path[len(root_path):],))
+
+            # Remove the trailing slash from the URL reverse generates if
+            # WAGTAIL_APPEND_SLASH is False and we're not trying to serve
+            # the root path
+            if not WAGTAIL_APPEND_SLASH and page_path != '/':
+                page_path = page_path.rstrip('/')
+
+            return (site_id, root_url, page_path)
+
+
 def _update_translation_descendant_url_paths(old_record, page):
     # update children paths, must be done for all languages to ensure fallbacks are applied
     languages_changed = []
@@ -431,27 +488,6 @@ def _update_untranslated_descendants_url_paths(page, languages_changed):
         for language in languages_changed:
             _localized_set_url_path(child, page, language)
         child.save(update_fields=update_fields)  # this will trigger any required saves downstream
-
-
-def _get_site_root_paths_decorator(func):
-    """
-    Resets cached site_root_paths if language is different than cached value
-    """
-    @wraps(func)
-    def wrapper(self, *args, **kwargs):
-        current_language = get_language()
-        request = args[0] if len(args) > 0 else None
-        cache_object = request if request else self
-        try:
-            if cache_object._wagtail_cached_site_root_paths_language != current_language:
-                cache.delete('wagtail_site_root_paths')
-                del cache_object._wagtail_cached_site_root_paths
-                cache_object._wagtail_cached_site_root_paths_language = current_language
-        except AttributeError:
-            cache_object._wagtail_cached_site_root_paths_language = current_language
-
-        return func(self, *args, **kwargs)
-    return wrapper
 
 
 class LocalizedSaveDescriptor(object):
@@ -497,6 +533,11 @@ class LocalizedSaveDescriptor(object):
         # update children localized paths if any language had it slug changed
         if change_descendant_url_path:
             _update_translation_descendant_url_paths(old_record, instance)
+
+        # Check if this is a root page of any sites and clear the 'wagtail_site_root_paths_XX' key if so
+        if Site.objects.filter(root_page=instance).exists():
+            for language in mt_settings.AVAILABLE_LANGUAGES:
+                cache.delete('wagtail_site_root_paths_{}'.format(language))
 
         return result
 

--- a/wagtail_modeltranslation/tests/tests.py
+++ b/wagtail_modeltranslation/tests/tests.py
@@ -837,6 +837,38 @@ class WagtailModeltranslationTest(WagtailModeltranslationTestBase):
         self.assertEqual(page_01.url, '/en/url-en-01/')
         self.assertEqual(page_02.url, '/en/url-de-02/')
 
+    def test_root_page_slug(self):
+        site_pages = {
+            'model': models.TestRootPage,
+            'kwargs': {'title': 'root URL', 'slug_de': 'root-de', 'slug_en': 'root-en'},
+            'children': {
+                'child1': {
+                    'model': models.TestSlugPage1,
+                    'kwargs': {'title': 'child1 URL', 'slug_de': 'url-de-01', 'slug_en': 'url-en-01'},
+                },
+                'child2': {
+                    'model': models.TestSlugPage2,
+                    'kwargs': {'title': 'child2 URL', 'slug': 'url-de-02'},
+                },
+            },
+        }
+        page_factory.create_page_tree(site_pages)
+
+        wagtail_page_01 = site_pages['children']['child1']['instance']
+        wagtail_page_02 = site_pages['children']['child2']['instance']
+
+        self.assertEqual(wagtail_page_01.url, '/de/url-de-01/')
+        self.assertEqual(wagtail_page_01.url_path, '/root-de/url-de-01/')
+        self.assertEqual(wagtail_page_02.url, '/de/url-de-02/')
+        self.assertEqual(wagtail_page_02.url_path, '/root-de/url-de-02/')
+
+        trans_real.activate('en')
+
+        self.assertEqual(wagtail_page_01.url, '/en/url-en-01/')
+        self.assertEqual(wagtail_page_01.url_path, '/root-en/url-en-01/')
+        self.assertEqual(wagtail_page_02.url, '/en/url-de-02/')
+        self.assertEqual(wagtail_page_02.url_path, '/root-en/url-de-02/')
+
     def test_set_translation_url_paths_command(self):
         """
         Assert set_translation_url_paths management command works correctly

--- a/wagtail_modeltranslation/tests/util.py
+++ b/wagtail_modeltranslation/tests/util.py
@@ -1,5 +1,3 @@
-
-
 class PageFactory(object):
 
     def __init__(self, initial_path=0):
@@ -33,12 +31,24 @@ class PageFactory(object):
         if not nodes:
             return None
 
+        from .models import TestRootPage
         try:
             from wagtail.core.models import Site
         except ImportError:
             from wagtail.wagtailcore.models import Site
-        root_node = self.create_instance(nodes)
-        site = Site.objects.create(root_page=root_node)
+
+        # add a top root node to mimic Wagtail's real behaviour
+        all_nodes = {
+            'model': TestRootPage,
+            'kwargs': {'title': 'Root', 'slug': 'root', },
+            'children': {
+                'site_root': nodes,
+            },
+        }
+        self.create_instance(all_nodes)
+
+        site_root_node = nodes['instance']
+        site = Site.objects.create(root_page=site_root_node, hostname='localhost', port=80, is_default_site=True)
         return site
 
     def create_instance(self, node, parent=None, order=None):


### PR DESCRIPTION
Fixes #195

In https://github.com/infoportugal/wagtail-modeltranslation/issues/195#issuecomment-376732049 @dwasyl has uncovered that `Site.get_site_root_paths()` returns a cached copy of site root paths which can be of the wrong language causing `Page.url` to return `None`.

Changes in this PR:

- Change `PageFactory.create_page_tree()` to return a page structure that better mimics Wagtail's live behaviour
- Failing test
- ~~Decorator to clear the cached sites if the language changed.~~
- Monkey patches `Page._get_site_root_paths()` so it returns site root paths for the current language
- For Wagtail<1.11 monkey patch `Page.get_url_parts()` with the most recent code which calls `Page._get_site_root_paths()`