### PR TITLE
Fix django.core.urlresolvers  import  for django 2

### DIFF
--- a/wagtail_modeltranslation/patch_wagtailadmin.py
+++ b/wagtail_modeltranslation/patch_wagtailadmin.py
@@ -5,7 +5,10 @@ import types
 
 from django.core.cache import cache
 from django.core.exceptions import ValidationError
-from django.core.urlresolvers import reverse
+try:
+    from django.core.urlresolvers import reverse
+except ImportError:
+    from django.urls import reverse
 from django.db import transaction, connection
 from django.db.models import Q, Value
 from django.db.models.functions import Concat, Substr


### PR DESCRIPTION
hi,
I had to do  this before I could try wagtail-modeltranslation with django2.
I do it like in the file :  templatetags/wagtail_modeltranslation.py
thanks

Laurent
