### PR TITLE
Fix diacritics downcoding in slugs

### DIFF
--- a/wagtail_modeltranslation/static/wagtail_modeltranslation/js/wagtail_translated_slugs.js
+++ b/wagtail_modeltranslation/static/wagtail_modeltranslation/js/wagtail_translated_slugs.js
@@ -8,13 +8,13 @@ $(document).ready(function () {
             $('#id_title_' + lang_code).on('focus', function () {
                 /* slug should only follow the title field if its value matched the title's value at the time of focus */
                 var currentSlug = $('#id_slug_' + lang_code).val();
-                var slugifiedTitle = cleanForSlug(this.value);
+                var slugifiedTitle = cleanForSlug(this.value, true);
                 slugFollowsTitle = (currentSlug == slugifiedTitle);
             });
 
             $('#id_title_' + lang_code).on('keyup keydown keypress blur', function () {
                 if (slugFollowsTitle) {
-                    var slugifiedTitle = cleanForSlug(this.value);
+                    var slugifiedTitle = cleanForSlug(this.value, true);
                     $('#id_slug_' + lang_code).val(slugifiedTitle);
                 }
             });


### PR DESCRIPTION
This change correctly downcodes diacritics to ASCII if user has WAGTAIL_ALLOW_UNICODE_SLUGS = False (e.g. abčďéfg -> abcdefg)
Without this change, the slug simply strips all diacritics which is not ideal (e.g. abčďěfg -> abfg)

cleanForSlug function uses URLify if the second parameter is true:
https://github.com/wagtail/wagtail/blob/0dacda913337d6a24c962b906811b857679831b2/wagtail/admin/static_src/wagtailadmin/js/page-editor.js#L240
Vanilla Wagtail correctly calls cleanForSlug with useURLify set to true (when following title).

Previously cleanForSlug only had one parameter, but AFAIK javascript doesn't care if a function is called with more parameters than specified.