### PR TITLE
Add migrate module to INSTALLED_APPS setting list

### DIFF
--- a/docs/Installation.rst
+++ b/docs/Installation.rst
@@ -48,6 +48,7 @@ To setup the application please follow these steps:
                 ...
                 'wagtail_modeltranslation',
                 'wagtail_modeltranslation.makemigrations',
+                'wagtail_modeltranslation.migrate',
             )
 
     - Add 'django.middleware.locale.LocaleMiddleware' to ``MIDDLEWARE`` (``MIDDLEWARE_CLASSES`` before django 1.10).


### PR DESCRIPTION
Updated documentation, added missing 'wagtail_modeltranslation.migrate' in Quick Setup section.