### PR TITLE
Update apps.py

### DIFF
--- a/wagtail_modeltranslation/apps.py
+++ b/wagtail_modeltranslation/apps.py
@@ -21,10 +21,10 @@ class ModeltranslationConfig(AppConfig):
         # update both the standard settings and the modeltranslation settings,
         # as we cannot guarantee the load order, and so django_modeltranslation
         # may bootstrap itself either before, or after, our ready() gets called.
-        custom_fields = getattr(settings, 'MODELTRANSLATION_CUSTOM_FIELDS', ())
+        custom_fields = getattr(settings, 'MODELTRANSLATION_CUSTOM_FIELDS', list())
         setattr(settings, 'MODELTRANSLATION_CUSTOM_FIELDS', list(set(custom_fields + wagtail_fields)))
 
-        mt_custom_fields = getattr(mt_settings, 'CUSTOM_FIELDS', ())
+        mt_custom_fields = getattr(mt_settings, 'CUSTOM_FIELDS', list())
         setattr(mt_settings, 'CUSTOM_FIELDS', list(set(mt_custom_fields + wagtail_fields)))
 
         from modeltranslation.models import handle_translation_registrations

--- a/wagtail_modeltranslation/apps.py
+++ b/wagtail_modeltranslation/apps.py
@@ -21,11 +21,11 @@ class ModeltranslationConfig(AppConfig):
         # update both the standard settings and the modeltranslation settings,
         # as we cannot guarantee the load order, and so django_modeltranslation
         # may bootstrap itself either before, or after, our ready() gets called.
-        custom_fields = getattr(settings, 'MODELTRANSLATION_CUSTOM_FIELDS', list())
-        setattr(settings, 'MODELTRANSLATION_CUSTOM_FIELDS', list(set(custom_fields + wagtail_fields)))
+        custom_fields = getattr(settings, 'MODELTRANSLATION_CUSTOM_FIELDS', tuple())
+        setattr(settings, 'MODELTRANSLATION_CUSTOM_FIELDS', tuple(set(custom_fields + wagtail_fields)))
 
-        mt_custom_fields = getattr(mt_settings, 'CUSTOM_FIELDS', list())
-        setattr(mt_settings, 'CUSTOM_FIELDS', list(set(mt_custom_fields + wagtail_fields)))
+        mt_custom_fields = getattr(mt_settings, 'CUSTOM_FIELDS', tuple())
+        setattr(mt_settings, 'CUSTOM_FIELDS', tuple(set(mt_custom_fields + wagtail_fields)))
 
         from modeltranslation.models import handle_translation_registrations
         handle_translation_registrations()

--- a/wagtail_modeltranslation/apps.py
+++ b/wagtail_modeltranslation/apps.py
@@ -10,9 +10,22 @@ class ModeltranslationConfig(AppConfig):
 
     def ready(self):
         from django.conf import settings
+        from modeltranslation import settings as mt_settings
+
         # Add Wagtail defined fields as modeltranslation custom fields
-        setattr(settings, 'MODELTRANSLATION_CUSTOM_FIELDS', getattr(settings, 'MODELTRANSLATION_CUSTOM_FIELDS', ()) + (
-            'StreamField', 'RichTextField'))
+        wagtail_fields = (
+            'StreamField',
+            'RichTextField',
+        )
+
+        # update both the standard settings and the modeltranslation settings,
+        # as we cannot guarantee the load order, and so django_modeltranslation
+        # may bootstrap itself either before, or after, our ready() gets called.
+        custom_fields = getattr(settings, 'MODELTRANSLATION_CUSTOM_FIELDS', ())
+        setattr(settings, 'MODELTRANSLATION_CUSTOM_FIELDS', list(set(custom_fields + wagtail_fields)))
+
+        mt_custom_fields = getattr(mt_settings, 'CUSTOM_FIELDS', ())
+        setattr(mt_settings, 'CUSTOM_FIELDS', list(set(mt_custom_fields + wagtail_fields)))
 
         from modeltranslation.models import handle_translation_registrations
         handle_translation_registrations()


### PR DESCRIPTION
From https://github.com/infoportugal/wagtail-modeltranslation/issues/234#issuecomment-474096604, the timing between django-modeltranslation and wagtail-modeltranslation leads to wmt updating the settings variable for dmt too late (namely, after dmt already read it out). This PR ensures that the `CUSTOM_FIELDS` value is set directly on dmt's settings. This fixes the (original) issue reported in https://github.com/infoportugal/wagtail-modeltranslation/issues/234