### PR TITLE
Fixed missing copy buttons for Wagtail 2.6.x.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,13 @@
 [tox]
 envlist =
+    py37-2.6.X,
+    py36-2.6.X,
+    py35-2.6.X,
+    py34-2.6.X,
+    py37-2.5.X,
+    py36-2.5.X,
+    py35-2.5.X,
+    py34-2.5.X,
     py37-2.4.X,
     py36-2.4.X,
     py35-2.4.X,
@@ -28,6 +36,46 @@ envlist =
 [testenv]
 commands =
     {envpython} runtests.py
+
+[testenv:py37-2.6.X]
+basepython = python3.7
+deps =
+    wagtail>=2.6,<2.7
+
+[testenv:py36-2.6.X]
+basepython = python3.6
+deps =
+    wagtail>=2.6,<2.7
+
+[testenv:py35-2.6.X]
+basepython = python3.5
+deps =
+    wagtail>=2.6,<2.7
+
+[testenv:py34-2.6.X]
+basepython = python3.4
+deps =
+    wagtail>=2.6,<2.7
+
+[testenv:py37-2.5.X]
+basepython = python3.7
+deps =
+    wagtail>=2.5,<2.6
+
+[testenv:py36-2.5.X]
+basepython = python3.6
+deps =
+    wagtail>=2.5,<2.6
+
+[testenv:py35-2.5.X]
+basepython = python3.5
+deps =
+    wagtail>=2.5,<2.6
+
+[testenv:py34-2.5.X]
+basepython = python3.4
+deps =
+    wagtail>=2.5,<2.6
 
 [testenv:py37-2.4.X]
 basepython = python3.7

--- a/wagtail_modeltranslation/static/wagtail_modeltranslation/js/copy_stream_fields.js
+++ b/wagtail_modeltranslation/static/wagtail_modeltranslation/js/copy_stream_fields.js
@@ -8,7 +8,12 @@ $(document).ready(function(){
 		//Current Field with all content
 		var currentStreamField = allStreamFields[i];
 		//Current Field header
-		var header = $(currentStreamField).children('h2')[0];
+    var header;
+    if(versionCompare(WAGTAIL_VERSION,'2.6.0')===-1){
+      header = $(currentStreamField).children('h2')[0];
+    } else {
+      header = $(currentStreamField).children('.title-wrapper')[0];
+    }
 		//Search for the input field so that we can get is id to know the field's name.
 		var streamFieldDiv = $(currentStreamField).find('div.sequence-container.sequence-type-stream')[0];
 		var fieldInfos = $(streamFieldDiv).children('input')[0].id.split('-')[0];
@@ -22,7 +27,7 @@ $(document).ready(function(){
 			if (fieldLang != langs[j]) {
 				var currentFieldID = fieldName + '_' + fieldLang;
 				var targetFieldID = fieldName + '_' + langs [j];
-				$(header).children('.translation-field-copy-wrapper')[0].innerHTML += '<button class="translation-field-copy" current-lang-code="'+ currentFieldID +'" data-lang-code="'+ targetFieldID +'">'+langs[j]+'</button>';
+				$(header).children('.translation-field-copy-wrapper')[0].innerHTML += '<button class="button translation-field-copy" current-lang-code="'+ currentFieldID +'" data-lang-code="'+ targetFieldID +'">'+langs[j]+'</button>';
 			};
 		};
 	};

--- a/wagtail_modeltranslation/static/wagtail_modeltranslation/js/version_compare.js
+++ b/wagtail_modeltranslation/static/wagtail_modeltranslation/js/version_compare.js
@@ -1,0 +1,76 @@
+/**
+ * Compares two software version numbers (e.g. "1.7.1" or "1.2b").
+ *
+ * This function was born in http://stackoverflow.com/a/6832721.
+ *
+ * @param {string} v1 The first version to be compared.
+ * @param {string} v2 The second version to be compared.
+ * @param {object} [options] Optional flags that affect comparison behavior:
+ * <ul>
+ *     <li>
+ *         <tt>lexicographical: true</tt> compares each part of the version strings lexicographically instead of
+ *         naturally; this allows suffixes such as "b" or "dev" but will cause "1.10" to be considered smaller than
+ *         "1.2".
+ *     </li>
+ *     <li>
+ *         <tt>zeroExtend: true</tt> changes the result if one version string has less parts than the other. In
+ *         this case the shorter string will be padded with "zero" parts instead of being considered smaller.
+ *     </li>
+ * </ul>
+ * @returns {number|NaN}
+ * <ul>
+ *    <li>0 if the versions are equal</li>
+ *    <li>a negative integer iff v1 < v2</li>
+ *    <li>a positive integer iff v1 > v2</li>
+ *    <li>NaN if either version string is in the wrong format</li>
+ * </ul>
+ *
+ * @copyright by Jon Papaioannou (["john", "papaioannou"].join(".") + "@gmail.com")
+ * @license This function is in the public domain. Do what you want with it, no strings attached.
+ */
+function versionCompare(v1, v2, options) {
+  var lexicographical = options && options.lexicographical,
+      zeroExtend = options && options.zeroExtend,
+      v1parts = v1.split('.'),
+      v2parts = v2.split('.');
+
+  function isValidPart(x) {
+      return (lexicographical ? /^\d+[A-Za-z]*$/ : /^\d+$/).test(x);
+  }
+
+  if (!v1parts.every(isValidPart) || !v2parts.every(isValidPart)) {
+      return NaN;
+  }
+
+  if (zeroExtend) {
+      while (v1parts.length < v2parts.length) v1parts.push("0");
+      while (v2parts.length < v1parts.length) v2parts.push("0");
+  }
+
+  if (!lexicographical) {
+      v1parts = v1parts.map(Number);
+      v2parts = v2parts.map(Number);
+  }
+
+  for (var i = 0; i < v1parts.length; ++i) {
+      if (v2parts.length == i) {
+          return 1;
+      }
+
+      if (v1parts[i] == v2parts[i]) {
+          continue;
+      }
+      else if (v1parts[i] > v2parts[i]) {
+          return 1;
+      }
+      else {
+          return -1;
+      }
+  }
+
+  if (v1parts.length != v2parts.length) {
+      return -1;
+  }
+
+  return 0;
+}

--- a/wagtail_modeltranslation/wagtail_hooks.py
+++ b/wagtail_modeltranslation/wagtail_hooks.py
@@ -17,10 +17,12 @@ try:
     from wagtail.core import hooks
     from wagtail.core.models import Page
     from wagtail.core.rich_text.pages import PageLinkHandler
+    from wagtail.core import __version__ as WAGTAIL_VERSION
 except ImportError:
     from wagtail.wagtailcore import hooks
     from wagtail.wagtailcore.models import Page
     from wagtail.wagtailcore.rich_text import PageLinkHandler
+    from wagtail.wagtailcore import __version__ as WAGTAIL_VERSION
 
 
 @hooks.register('insert_editor_js')
@@ -121,6 +123,7 @@ def streamfields_translation_copy():
 
     # includes the javascript file in the html file
     js_files = [
+        'wagtail_modeltranslation/js/version_compare.js',
         'wagtail_modeltranslation/js/copy_stream_fields.js',
     ]
 
@@ -128,7 +131,12 @@ def streamfields_translation_copy():
         (static(filename),) for filename in js_files)
     )
 
-    return js_includes
+    js_wagtail_version = """
+<script>
+    var WAGTAIL_VERSION='{wagtail_version}';
+</script>
+    """.format(wagtail_version=WAGTAIL_VERSION)
+    return format_html(js_wagtail_version) + js_includes
 
 
 @hooks.register('insert_editor_css')


### PR DESCRIPTION
Wagtail 2.6 introduced some changes in the admin layout.
Wagtail-modeltranslation now fails to add the copy buttons to the div containing the titles, this PR fixes this issue, trying to leave things unchanged for older versions of Wagtail.