### PR TITLE
Render form JS script tags in copy template

### DIFF
--- a/wagtail_modeltranslation/templates/modeltranslation_copy.html
+++ b/wagtail_modeltranslation/templates/modeltranslation_copy.html
@@ -28,4 +28,5 @@
 {% block extra_js %}
     {{ block.super }}
     {% include "wagtailadmin/pages/_editor_js.html" %}
+    {{ form.media.js }}
 {% endblock %}


### PR DESCRIPTION
This fixes an issue where the page selection widget on the copy form fails to function.

wagtail.admin.views.pages.copy() relies on a `CopyForm` which uses an `AdminPageChooser` widget for the `new_parent_page` field. `AdminPageChooser` relies on the inclusion of JS files to function correctly, as referenced in the `media` properly below.

The copy template thus requires the inclusion of `{{ form.media.js }}` to keep parity with the default Wagtail copy template (see: wagtailadmin/pages/copy.html).

```
    @property
    def media(self):
        return forms.Media(js=[
            versioned_static('wagtailadmin/js/page-chooser-modal.js'),
            versioned_static('wagtailadmin/js/page-chooser.js'),
        ])
```