### PR TITLE
Patch subclasses of SearchField for the search index

### DIFF
--- a/wagtail_modeltranslation/patch_wagtailadmin.py
+++ b/wagtail_modeltranslation/patch_wagtailadmin.py
@@ -102,7 +102,7 @@ class WagtailTranslator(object):
 
         for field in model.search_fields:
             # Check if the field is a SearchField and if it is one of the fields registered for translation
-            if field.__class__ is SearchField and field.field_name in translation_registered_fields:
+            if isinstance(field, SearchField) and field.field_name in translation_registered_fields:
                 # If it is we create a clone of the original SearchField to keep all the defined options
                 # and replace its name by the translated one
                 for language in mt_settings.AVAILABLE_LANGUAGES:


### PR DESCRIPTION
In a project I am working on I needed to subclass the index.SearchField- but this field wasn't handled by wagtail-modeltranslation.

The current code in wagtail-modeltranslation compares the class name instead of the instance type- i changed it, so that subclasses of SearchField are patched, too. 