### PR TITLE
Bugfix for "Copy Page" form not working when TRANSLATE_SLUGS = False

### DIFF
--- a/wagtail_modeltranslation/patch_wagtailadmin_forms.py
+++ b/wagtail_modeltranslation/patch_wagtailadmin_forms.py
@@ -9,6 +9,8 @@ from django.utils.translation import ungettext
 from django.utils.translation import activate, get_language
 from modeltranslation.utils import build_localized_fieldname
 
+from wagtail_modeltranslation import settings as wmt_settings
+
 try:
     from wagtail.core.models import Page
     from wagtail.admin import widgets
@@ -42,10 +44,13 @@ class PatchedCopyForm(CopyForm):
             locale_label = "{} [{}]".format(_("New title"), code)
             self.fields[locale_title] = forms.CharField(initial=self.page.title, label=locale_label)
 
-        for code, name in settings.LANGUAGES:
-            locale_title = "new_{}".format(build_localized_fieldname('slug', code))
-            locale_label = "{} [{}]".format(_("New slug"), code)
-            self.fields[locale_title] = forms.SlugField(initial=self.page.slug, label=locale_label)
+        if wmt_settings.TRANSLATE_SLUGS:
+            for code, name in settings.LANGUAGES:
+                locale_title = "new_{}".format(build_localized_fieldname('slug', code))
+                locale_label = "{} [{}]".format(_("New slug"), code)
+                self.fields[locale_title] = forms.SlugField(initial=self.page.slug, label=locale_label)
+        else:
+            self.fields['new_slug'] = forms.SlugField(initial=self.page.slug, label=_("New slug"))
 
         self.fields['new_parent_page'] = forms.ModelChoiceField(
             initial=self.page.get_parent(),

--- a/wagtail_modeltranslation/templates/modeltranslation_copy.html
+++ b/wagtail_modeltranslation/templates/modeltranslation_copy.html
@@ -14,10 +14,6 @@
                 {% for field in form.visible_fields %}
              	    {% include "wagtailadmin/shared/field_as_li.html" with field=field %}
              	{% endfor %}
-
-                {% if form.copy_subpages %}
-                    {% include "wagtailadmin/shared/field_as_li.html" with field=form.copy_subpages %}
-                {% endif %}
             </ul>
 
             <input type="submit" value="{% trans 'Copy this page' %}" class="button">

--- a/wagtail_modeltranslation/wagtail_hooks.py
+++ b/wagtail_modeltranslation/wagtail_hooks.py
@@ -236,7 +236,10 @@ def before_copy_page(request, page):
 
             update_attrs = {}
             for code, name in settings.LANGUAGES:
-                slug = build_localized_fieldname('slug', code)
+                if wmt_settings.TRANSLATE_SLUGS:
+                    slug = build_localized_fieldname('slug', code)
+                else:
+                    slug = 'slug'
                 title = build_localized_fieldname('title', code)
                 update_attrs[slug] = form.cleaned_data["new_{}".format(slug)]
                 update_attrs[title] = form.cleaned_data["new_{}".format(title)]


### PR DESCRIPTION
This directly addresses issue #283.

This fixes a bug where the "Copy Page" form would always show multiple language fields for the `new_slug` field even if `WAGTAILMODELTRANSLATION_TRANSLATE_SLUGS` is set to `False` in your project.