### PR TITLE
Fix toggle compatibility for CodeRed

### DIFF
--- a/wagtail_modeltranslation/static/wagtail_modeltranslation/js/language_toggles.js
+++ b/wagtail_modeltranslation/static/wagtail_modeltranslation/js/language_toggles.js
@@ -3,7 +3,7 @@ jQuery( () => {
 ///////////////
 
 const tabbedContent = $(`form .tab-content`);
-const topLevel = (tabbedContent.length > 0) ? tabbedContent : $(`.content form`);
+const topLevel = (tabbedContent.length > 0) ? tabbedContent.first() : $(`.content form`);
 const languageCodeRegex = new RegExp(' \\[('+wagtailModelTranslations.languages.join('|')+')\\]');
 
 if (topLevel.length === 0) {


### PR DESCRIPTION
While using [CodeRed](https://docs.coderedcorp.com/cms/stable/how_to/translation.html) I stumbled on their issue [#317](https://github.com/coderedcorp/coderedcms/issues/317), where language toggle buttons do not work and make the page reload.

This happens because the click listeners are added to **each** top-level element, instead of just the first one (CodeRed adds multiple `.tab-content` elements, which break the current code).

The proposed fix is to add the toggle buttons to just the first `.tab-element` of the page.