### PR TITLE
Fix autocreation of slugs

### DIFF
--- a/wagtail_modeltranslation/wagtail_hooks.py
+++ b/wagtail_modeltranslation/wagtail_hooks.py
@@ -54,7 +54,7 @@ def translated_slugs():
             languages: [{languages}],
             defaultLanguage: '{language_code}',
             viewEditString: '{view_edit_string}',
-            translate_slugs: '{translate_slugs}',
+            translate_slugs: {translate_slugs},
         }};
     </script>
     """.format(


### PR DESCRIPTION
Commit 514f589 ("Hotfix: undefined variables in JS due to bad merge")
overquoted translate_slugs, so that Javascript doesn't get the boolean
values `true` or `false`, but the strings `'true'` or `'false'` instead,
which both evalute to true in the Javascript code.

As an effect, slugs are no longer autocreated for the language agnostic
"#id_slug" field even if TRANSLATE_SLUGS is not set or set to False. If
the user doesn't manually enter a slug string, the page fails validation
with "This field is required."

Remove quotes from transate_slugs.

Fixes infoportugal/wagtail-modeltranslation#293