### PR TITLE
Use DEFAULT_LANGUAGE from django-modeltranslation

### DIFF
--- a/wagtail_modeltranslation/wagtail_hooks.py
+++ b/wagtail_modeltranslation/wagtail_hooks.py
@@ -14,6 +14,7 @@ from django.views.decorators.csrf import csrf_exempt
 from six import iteritems
 
 from modeltranslation.utils import build_localized_fieldname
+from modeltranslation import settings as mt_settings
 from wagtail_modeltranslation import settings as wmt_settings
 
 from .patch_wagtailadmin_forms import PatchedCopyForm
@@ -59,7 +60,7 @@ def translated_slugs():
     </script>
     """.format(
         languages=", ".join(lang_codes),
-        language_code=settings.LANGUAGE_CODE,
+        language_code=mt_settings.DEFAULT_LANGUAGE,
         view_edit_string=_('View / edit fields for'),
         translate_slugs='true' if wmt_settings.TRANSLATE_SLUGS else 'false'
     )


### PR DESCRIPTION
With a setting like this:

    LANGUAGE_CODE = 'en-us'
    LANGUAGES = (
        ('en', _('English')),
        ('de', _('German')),
    )

LANGUAGE_CODE includes a country and is not enumerated in LANGUAGES.
This causes the autogeneration of (untranslated) slugs to fail and all
language toggles to default to off.

Use MODELTRANSLATION_DEFAULT_LANGUAGE instead of LANGUAGE_CODE.

MODELTRANSLATION_DEFAULT_LANGUAGE is defaulted to the first element of
MODELTRANSLATION_LANGUAGES which is defaulted to LANGUAGES [1].

If the user overwrites, it is verified, that
MODELTRANSLATION_DEFAULT_LANGUAGE is one of the languages availabe in
MODELTRANSLATION_LANGUAGES [1].

This fixes the problem mentioned in #287 (comment), although it is not the original topic of #287

[1] https://github.com/deschler/django-modeltranslation/blob/master/modeltranslation/settings.py
