### PR TITLE
Add "finished building" event for third party JS to hook into

### DIFF
--- a/wagtail_modeltranslation/static/wagtail_modeltranslation/js/language_toggles.js
+++ b/wagtail_modeltranslation/static/wagtail_modeltranslation/js/language_toggles.js
@@ -75,6 +75,7 @@ function filterForLocale(index, element) {
  */
 function buildSets(topElement) {
   $(`li.object:not(.multi-field), div.field`, topElement).each( filterForLocale );
+  document.dispatchEvent(new CustomEvent('wagtail-modeltranslation:buildSets:done'));
 }
 
 /**


### PR DESCRIPTION
Adds an event dispatch at the end of `buildSets` so that third party JS that needs to run "on page load" can also listen for this event in order to do things to the DOM based on a knowledge that locale fields may now be hidden.

See related issue https://github.com/infoportugal/wagtail-modeltranslation/issues/306