### PR TITLE
added CUSTOM_INLINE_PANELS setting

### DIFF
--- a/docs/advanced settings.rst
+++ b/docs/advanced settings.rst
@@ -30,6 +30,18 @@ This setting behaves as the above but should be used for panels that are compose
     WAGTAILMODELTRANSLATION_CUSTOM_COMPOSED_PANELS = ['app_x.module_y.PanelZ']
 
 
+``WAGTAILMODELTRANSLATION_CUSTOM_INLINE_PANELS``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Default: ``[]`` (empty list)
+
+This setting behaves as the above but should be used for panels that inherit InlinePanel.
+
+.. code-block:: python
+
+    WAGTAILMODELTRANSLATION_CUSTOM_INLINE_PANELS = ['app_x.module_y.PanelZ']
+
+
 ``WAGTAILMODELTRANSLATION_TRANSLATE_SLUGS``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/wagtail_modeltranslation/patch_wagtailadmin.py
+++ b/wagtail_modeltranslation/patch_wagtailadmin.py
@@ -43,7 +43,7 @@ except ImportError:
     from wagtail.wagtailimages.edit_handlers import ImageChooserPanel
     from wagtail.wagtailsearch.index import SearchField
     from wagtail.wagtailsnippets.views.snippets import SNIPPET_EDIT_HANDLERS
-from wagtail_modeltranslation.settings import CUSTOM_SIMPLE_PANELS, CUSTOM_COMPOSED_PANELS, TRANSLATE_SLUGS
+from wagtail_modeltranslation.settings import CUSTOM_SIMPLE_PANELS, CUSTOM_COMPOSED_PANELS, CUSTOM_INLINE_PANELS, TRANSLATE_SLUGS
 from wagtail_modeltranslation.utils import compare_class_tree_depth
 from wagtail_modeltranslation.patch_wagtailadmin_forms import patch_admin_page_form
 from wagtail import VERSION
@@ -52,7 +52,7 @@ logger = logging.getLogger('wagtail.core')
 
 SIMPLE_PANEL_CLASSES = [FieldPanel, ImageChooserPanel, StreamFieldPanel, RichTextFieldPanel] + CUSTOM_SIMPLE_PANELS
 COMPOSED_PANEL_CLASSES = [MultiFieldPanel, FieldRowPanel] + CUSTOM_COMPOSED_PANELS
-
+INLINE_PANEL_CLASSES = [InlinePanel] + CUSTOM_INLINE_PANELS
 
 class WagtailTranslator(object):
     _patched_models = []
@@ -163,7 +163,7 @@ class WagtailTranslator(object):
                 patched_panels += self._patch_simple_panel(current_patching_model, panel)
             elif panel.__class__ in COMPOSED_PANEL_CLASSES:
                 patched_panels.append(self._patch_composed_panel(panel, related_model))
-            elif panel.__class__ == InlinePanel:
+            elif panel.__class__ in INLINE_PANEL_CLASSES:
                 patched_panels.append(self._patch_inline_panel(current_patching_model, panel))
             else:
                 patched_panels.append(panel)

--- a/wagtail_modeltranslation/settings.py
+++ b/wagtail_modeltranslation/settings.py
@@ -10,6 +10,8 @@ CUSTOM_SIMPLE_PANELS = [import_from_string(panel_class) for panel_class in
                         getattr(settings, 'WAGTAILMODELTRANSLATION_CUSTOM_SIMPLE_PANELS', [])]
 CUSTOM_COMPOSED_PANELS = [import_from_string(panel_class) for panel_class in
                           getattr(settings, 'WAGTAILMODELTRANSLATION_CUSTOM_COMPOSED_PANELS', [])]
+CUSTOM_INLINE_PANELS = [import_from_string(panel_class) for panel_class in
+                          getattr(settings, 'WAGTAILMODELTRANSLATION_CUSTOM_INLINE_PANELS', [])]
 TRANSLATE_SLUGS = getattr(settings, 'WAGTAILMODELTRANSLATION_TRANSLATE_SLUGS', True)
 LOCALE_PICKER = getattr(settings, 'WAGTAILMODELTRANSLATION_LOCALE_PICKER', True)
 LOCALE_PICKER_DEFAULT = getattr(settings, 'WAGTAILMODELTRANSLATION_LOCALE_PICKER_DEFAULT', None)


### PR DESCRIPTION
This adds a CUSTOM_INLINE_PANELS settings, that works exactly like the other two CUSTOM_*_PANELS.

I needed this to have wagtail-modeltranslation work with wagtail-multi-upload, which provides a panel that inherits InlinePanel, that didn't got translated.

What do you think ?

Worth noting that it doesn't work 100% with wagtail-multi-upload, as all fields are still displayed when adding multiple images at once, but that's probably an issue that must be fixed on their side (missing some "inline added" javascript signal or something).