### PR TITLE
support third party adding inlines not using the Add button

### DIFF
--- a/wagtail_modeltranslation/static/wagtail_modeltranslation/js/language_toggles.js
+++ b/wagtail_modeltranslation/static/wagtail_modeltranslation/js/language_toggles.js
@@ -92,7 +92,8 @@ function getSelectedLocales() {
 /**
  * Adds event listeners on click for inlines.
 */
-$('a[id^=id_][id$=-ADD]').click(e => {
+// TODO : DOMNodeInserted is deprected, find a replacement for that
+$('#page-edit-form').on('DOMNodeInserted', '[data-inline-panel-child]', null, e => {
   e.preventDefault();
   // get the ul where all inlines will be added
   ulForms = $(e.currentTarget).parent().siblings('ul.multiple')[0];


### PR DESCRIPTION
Third party packages (in my case : wagtail-multi-upload) may add inlines without using the ADD button,
in which case wagtail-modeltranslation fails to hide the languages fields.

Rather than listening to a click on the add button, we could listen to the insertion of the inline itself, so that this case is supported.

**Problem** : it seems the `DOMNodeInserted` event is deprecated, and from a quick google search, it seems replacements are quite verbose... I'm not sure what's the best approach with that (not too fond of JS), so I'm leaving this as a draft for now, if anyone knows how to best implement this, comments are welcome !

