### PR TITLE
Fix issue with `change_lang` template tag

### DIFF
--- a/wagtail_modeltranslation/templatetags/wagtail_modeltranslation.py
+++ b/wagtail_modeltranslation/templatetags/wagtail_modeltranslation.py
@@ -48,7 +48,7 @@ def change_lang(context, lang=None, page=None, *args, **kwargs):
         # means that is an wagtail page object
         if match.url_name == 'wagtail_serve':
             activate(lang)
-            translated_url = page.url
+            translated_url = page.get_url()
             activate(current_language)
 
             return translated_url


### PR DESCRIPTION
Currently when using the template tag `change_lang` and the request url resolves to `wagtail_serve`, a value of `None` is returned.

The code activates the target language, retrieves the page url, reverts the language, and returns the result.

When debugging the `url` attribute of `page` was `None`. Internally the base Wagtail Page class defines `url` with the builtin `property` (not decorated) method and returns `get_url`.

My proposed change refactors use of the property to calling `get_url` directly. I have not been able to determine why the property returns `None` in this context. There may be a better systemic solution but this solved my issue.