### PR TITLE
Update language_toggles.js

### DIFF
--- a/wagtail_modeltranslation/static/wagtail_modeltranslation/js/language_toggles.js
+++ b/wagtail_modeltranslation/static/wagtail_modeltranslation/js/language_toggles.js
@@ -116,7 +116,7 @@ function buildLocaleToggler() {
 
   var toggles = {};
   locales.forEach( locale => {
-    var li = $(`<li class="locale"><button class="locale-toggle">${locale}</button></li>`);
+    var li = $(`<li class="locale"><button type="button" class="locale-toggle">${locale}</button></li>`);
     ul.append(li);
 
     $(`button.locale-toggle`, li).each( (index, toggle) => {


### PR DESCRIPTION
The default button type is "submit", which makes Enter-presses on a form toggle the language. Normally people expect an Enter-press to submit the form. This fixes that.