### PR TITLE
"Copy content from: ..." buttons fix

### DIFF
--- a/wagtail_modeltranslation/static/wagtail_modeltranslation/js/copy_stream_fields.js
+++ b/wagtail_modeltranslation/static/wagtail_modeltranslation/js/copy_stream_fields.js
@@ -61,6 +61,13 @@ function extractInputId(currentStreamField) {
 		var streamFieldDiv = $(currentStreamField).find('div.sequence-container.sequence-type-stream')[0];
 		var inputId = $(streamFieldDiv).children('input')[0].id.split('-')[0];
 	}
+	
+	if (!inputId) {
+		var streamFieldInput = $(currentStreamField).find('.field-content input')[0];
+		streamFieldInput.id = streamFieldInput.name;
+		var inputId = streamFieldInput.name.split('-')[0];
+	}
+	
 	return inputId;
 }
 


### PR DESCRIPTION
In recent wagtail versions, the streamfield input elements `id`'s have changed, and the outer `div` selector does not work anymore (again). This is a quick fix that modifies the `id` values (so that the buttons remain functional in a backwards-compatible way) and fixes the selector.

This fixes https://github.com/infoportugal/wagtail-modeltranslation/issues/337