### PR TITLE
Fix url for `copy_translation_content`

### DIFF
--- a/wagtail_modeltranslation/wagtail_hooks.py
+++ b/wagtail_modeltranslation/wagtail_hooks.py
@@ -164,7 +164,7 @@ def return_translation_target_field_rendered_html(request, page_id):
 @hooks.register('register_admin_urls')
 def copy_streamfields_content():
     return [
-        url(r'(?P<page_id>\d+)/edit/copy_translation_content/$',
+        url(r'pages/(?P<page_id>\d+)/edit/copy_translation_content/$',
             return_translation_target_field_rendered_html, name=''),
     ]
 


### PR DESCRIPTION
At the moment, the AJAX call to `copy_translation_content`  from https://github.com/infoportugal/wagtail-modeltranslation/blob/master/wagtail_modeltranslation/static/wagtail_modeltranslation/js/copy_stream_fields.js

points to an inexistent endpoint.

This should fix that