### PR TITLE
Update some imports for Wagtail v3.0

### DIFF
--- a/wagtail_modeltranslation/patch_wagtailadmin.py
+++ b/wagtail_modeltranslation/patch_wagtailadmin.py
@@ -20,29 +20,45 @@ from modeltranslation.translator import translator, NotRegistered
 from modeltranslation.utils import build_localized_fieldname, get_language
 
 try:
+    # for Wagtail v3.0
     from wagtail.contrib.routable_page.models import RoutablePageMixin
     from wagtail.admin.edit_handlers import FieldPanel, \
         MultiFieldPanel, FieldRowPanel, InlinePanel, StreamFieldPanel, RichTextFieldPanel,\
         extract_panel_definitions_from_model_class, ObjectList
     from wagtail.core.models import Page, Site
     from wagtail.core.fields import StreamField, StreamValue
-    from wagtail.core.url_routing import RouteResult
+    from wagtail.url_routing import RouteResult
     from wagtail.core.utils import WAGTAIL_APPEND_SLASH
     from wagtail.images.edit_handlers import ImageChooserPanel
     from wagtail.search.index import SearchField
     from wagtail.snippets.views.snippets import SNIPPET_EDIT_HANDLERS
 except ImportError:
-    from wagtail.contrib.wagtailroutablepage.models import RoutablePageMixin
-    from wagtail.wagtailadmin.edit_handlers import FieldPanel, \
-        MultiFieldPanel, FieldRowPanel, InlinePanel, StreamFieldPanel, RichTextFieldPanel,\
-        extract_panel_definitions_from_model_class, ObjectList
-    from wagtail.wagtailcore.models import Page, Site
-    from wagtail.wagtailcore.fields import StreamField, StreamValue
-    from wagtail.wagtailcore.url_routing import RouteResult
-    from wagtail.wagtailcore.utils import WAGTAIL_APPEND_SLASH
-    from wagtail.wagtailimages.edit_handlers import ImageChooserPanel
-    from wagtail.wagtailsearch.index import SearchField
-    from wagtail.wagtailsnippets.views.snippets import SNIPPET_EDIT_HANDLERS
+    # for Wagtail v2.16
+    try:
+        from wagtail.contrib.routable_page.models import RoutablePageMixin
+        from wagtail.admin.edit_handlers import FieldPanel, \
+            MultiFieldPanel, FieldRowPanel, InlinePanel, StreamFieldPanel, RichTextFieldPanel,\
+            extract_panel_definitions_from_model_class, ObjectList
+        from wagtail.core.models import Page, Site
+        from wagtail.core.fields import StreamField, StreamValue
+        from wagtail.core.url_routing import RouteResult
+        from wagtail.core.utils import WAGTAIL_APPEND_SLASH
+        from wagtail.images.edit_handlers import ImageChooserPanel
+        from wagtail.search.index import SearchField
+        from wagtail.snippets.views.snippets import SNIPPET_EDIT_HANDLERS
+    except ImportError:
+        # for Legacy Wagtail
+        from wagtail.contrib.wagtailroutablepage.models import RoutablePageMixin
+        from wagtail.wagtailadmin.edit_handlers import FieldPanel, \
+            MultiFieldPanel, FieldRowPanel, InlinePanel, StreamFieldPanel, RichTextFieldPanel,\
+            extract_panel_definitions_from_model_class, ObjectList
+        from wagtail.wagtailcore.models import Page, Site
+        from wagtail.wagtailcore.fields import StreamField, StreamValue
+        from wagtail.wagtailcore.url_routing import RouteResult
+        from wagtail.wagtailcore.utils import WAGTAIL_APPEND_SLASH
+        from wagtail.wagtailimages.edit_handlers import ImageChooserPanel
+        from wagtail.wagtailsearch.index import SearchField
+        from wagtail.wagtailsnippets.views.snippets import SNIPPET_EDIT_HANDLERS
 try:
     from wagtail.core.models import SiteRootPath
 except ImportError:

--- a/wagtail_modeltranslation/wagtail_hooks.py
+++ b/wagtail_modeltranslation/wagtail_hooks.py
@@ -20,17 +20,27 @@ from wagtail_modeltranslation import settings as wmt_settings
 from .patch_wagtailadmin_forms import PatchedCopyForm
 
 try:
+    # for Wagtail v3.0
     from wagtail.core import hooks
     from wagtail.core.models import Page
-    from wagtail.core.rich_text.pages import PageLinkHandler
-    from wagtail.core import __version__ as WAGTAIL_VERSION
+    from wagtail.rich_text.pages import PageLinkHandler
+    from wagtail import __version__ as WAGTAIL_VERSION
     from wagtail.admin import messages
 except ImportError:
-    from wagtail.wagtailcore import hooks
-    from wagtail.wagtailcore.models import Page
-    from wagtail.wagtailcore.rich_text import PageLinkHandler
-    from wagtail.wagtailcore import __version__ as WAGTAIL_VERSION
-    from wagtail.wagtailadmin import messages
+    try:
+        # for Wagtail v2.16
+        from wagtail.core import hooks
+        from wagtail.core.models import Page
+        from wagtail.core.rich_text.pages import PageLinkHandler
+        from wagtail.core import __version__ as WAGTAIL_VERSION
+        from wagtail.admin import messages
+    except ImportError:
+        # for legacy Wagtail
+        from wagtail.wagtailcore import hooks
+        from wagtail.wagtailcore.models import Page
+        from wagtail.wagtailcore.rich_text import PageLinkHandler
+        from wagtail.wagtailcore import __version__ as WAGTAIL_VERSION
+        from wagtail.wagtailadmin import messages
 
 from wagtail import __version__ as wagtail_version
 from distutils.version import LooseVersion


### PR DESCRIPTION
The migration command was not working for me after upgrading Wagtail to version 3.0. I traced the problem back to some import paths. I just changed the ones that caused the trouble for me. The whole package has to be revised in this regard, I reckon.