### PR TITLE
Fixed deprecated hook for wagtail>=5.1

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -36,9 +36,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python: ["3.8", "3.9", "3.10", "3.11"]
         django-modeltranslation: ["0.17", "0.18"]
-        wagtail: ["4.0", "4.1", "5.0"]
+        wagtail: ["4.0", "4.1", "5.0", "5.1"]
         database: ["sqlite", "postgres", "mysql"]
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/wagtail_modeltranslation/templates/modeltranslation_copy.html
+++ b/wagtail_modeltranslation/templates/modeltranslation_copy.html
@@ -12,7 +12,9 @@
 
             <ul class="fields">
                 {% for field in form.visible_fields %}
-             	    {% include "wagtailadmin/shared/field_as_li.html" with field=field %}
+             	    <li>
+                        {% include "wagtailadmin/shared/field.html" %}
+                    </li>
              	{% endfor %}
             </ul>
 

--- a/wagtail_modeltranslation/tests/settings.py
+++ b/wagtail_modeltranslation/tests/settings.py
@@ -48,7 +48,6 @@ INSTALLED_APPS = [
     'wagtail.contrib.frontend_cache',
     'wagtail.contrib.search_promotions',
     'wagtail.contrib.settings',
-    'wagtail.contrib.modeladmin',
     'wagtail.contrib.table_block',
     'wagtail.contrib.forms',
 

--- a/wagtail_modeltranslation/wagtail_hooks.py
+++ b/wagtail_modeltranslation/wagtail_hooks.py
@@ -17,12 +17,18 @@ from wagtail_modeltranslation import settings as wmt_settings
 
 from .patch_wagtailadmin_forms import PatchedCopyForm
 
-from wagtail import hooks
+from wagtail import hooks, VERSION as _WAGTAIL_VERSION
 from wagtail.models import Page
 from wagtail.rich_text.pages import PageLinkHandler
 from wagtail.admin import messages
 
 from wagtail.admin.views.pages.utils import get_valid_next_url_from_request
+
+if _WAGTAIL_VERSION >= (5, 1):
+    # https://docs.wagtail.org/en/stable/releases/5.1.html#insert-editor-css-hook-is-deprecated
+    _HOOK_INSERT_CSS = 'insert_global_admin_css'
+else:
+    _HOOK_INSERT_CSS = 'insert_editor_css'
 
 
 @hooks.register('insert_editor_js')
@@ -174,20 +180,20 @@ def streamfields_translation_copy():
     return js_includes
 
 
-@hooks.register('insert_editor_css')
+@hooks.register(_HOOK_INSERT_CSS)
 def modeltranslation_page_editor_css():
     filename = 'wagtail_modeltranslation/css/page_editor_modeltranslation.css'
-    return format_html('<link rel="stylesheet" href="{}" >'.format(static(filename)))
+    return format_html('<link rel="stylesheet" href="{}">', static(filename))
 
 
-@hooks.register('insert_editor_css')
+@hooks.register(_HOOK_INSERT_CSS)
 def modeltranslation_page_editor_titles_css():
     """
     Patch admin styles, in particular page title headings missing in Wagtail 4
     """
 
     filename = 'wagtail_modeltranslation/css/admin_patch.css'
-    return format_html('<link rel="stylesheet" href="{}" >'.format(static(filename)))
+    return format_html('<link rel="stylesheet" href="{}">', static(filename))
 
 
 @hooks.register('register_rich_text_link_handler')


### PR DESCRIPTION
Concerns the following Wagtail 5.1 deprecations: 

- https://docs.wagtail.org/en/stable/releases/5.1.html#removed-support-for-python-3-7
- https://docs.wagtail.org/en/stable/releases/5.1.html#insert-editor-css-hook-is-deprecated
- https://docs.wagtail.org/en/stable/releases/5.1.html#shared-include-field-as-li-html-will-be-removed
- https://docs.wagtail.org/en/stable/releases/5.1.html#wagtail-contrib-modeladmin-is-deprecated