### PR TITLE
Update language_toggles.js

### DIFF
--- a/wagtail_modeltranslation/static/wagtail_modeltranslation/js/language_toggles.js
+++ b/wagtail_modeltranslation/static/wagtail_modeltranslation/js/language_toggles.js
@@ -2,7 +2,7 @@
 jQuery( () => {
 ///////////////
 
-const tabbedContent = $(`form .tab-content`);
+const tabbedContent = $(`form .tab-content, form .nice-padding`);
 const topLevel = (tabbedContent.length > 0) ? tabbedContent.first() : $(`.content > form`);
 const languageCodeRegex = new RegExp(' \\[('+wagtailModelTranslations.languages.join('|')+')\\]');
 


### PR DESCRIPTION
In Wagtail 5.1 (maybe earlier) Snippets (`/cms/snippets/<x>/<y>/edit/1/`) don't have a ".tab-content" anymore; they do have a `.nice-padding` though.