### PR TITLE
Fix TitleFieldPanel patching

### DIFF
--- a/wagtail_modeltranslation/patch_wagtailadmin.py
+++ b/wagtail_modeltranslation/patch_wagtailadmin.py
@@ -201,13 +201,15 @@ class WagtailTranslator(object):
                     localized_panel = panel_class(
                         localized_field_name,
                         targets=[build_localized_fieldname(target, language)
-                                 for target in original_panel.targets])
+                                 for target in original_panel.targets],
+                        apply_if_live=original_panel.apply_if_live)
                 elif language == mt_settings.DEFAULT_LANGUAGE:
                     # Slugs are not translated, so when a title field in the default language is
                     # updated we must update the slug it is linked to.
                     localized_panel = panel_class(
                         localized_field_name,
-                        targets=original_panel.targets)
+                        targets=original_panel.targets,
+                        apply_if_live=original_panel.apply_if_live)
                 else:
                     # Slugs are not translated and this title field is in a non-default language.
                     # There is no slug to link the title to, so the TitleFieldPanel becomes a

--- a/wagtail_modeltranslation/patch_wagtailadmin.py
+++ b/wagtail_modeltranslation/patch_wagtailadmin.py
@@ -194,7 +194,7 @@ class WagtailTranslator(object):
                 new_stream_block.meta.required = False
                 localized_field.stream_block = new_stream_block
 
-            if panel_class == TitleFieldPanel and TRANSLATE_SLUGS:
+            if panel_class == TitleFieldPanel:
                 if TRANSLATE_SLUGS:
                     # When a title field is changed its corresponding localized slug may need to
                     # be updated.
@@ -212,7 +212,7 @@ class WagtailTranslator(object):
                     # Slugs are not translated and this title field is in a non-default language.
                     # There is no slug to link the title to, so the TitleFieldPanel becomes a
                     # plain FieldPanel.
-                    localized_panel = FieldPanel(localized_field_name)
+                    localized_panel = FieldPanel(localized_field_name, classname="title")
             else:
                 localized_panel = panel_class(localized_field_name)
 

--- a/wagtail_modeltranslation/static/wagtail_modeltranslation/css/admin_patch.css
+++ b/wagtail_modeltranslation/static/wagtail_modeltranslation/css/admin_patch.css
@@ -21,13 +21,14 @@
 .w-panel.title .Draftail-Editor .public-DraftEditor-content,
 .w-panel.title input,
 .w-panel.title textarea {
- color:var(--w-color-primary);
- color:var(--w-color-grey-600);
- font-size:1.875rem;
- font-weight:800;
- line-height:1.3;
- margin-inline-start:-.375rem;
- padding-inline-start:.375rem;
+    color:var(--w-color-primary);
+    color:var(--w-color-grey-600);
+    color:var(--w-color-text-context);
+    font-size:1.875rem;
+    font-weight:800;
+    line-height:1.3;
+    margin-inline-start:-.375rem;
+    padding-inline-start:.375rem;
 }
 .w-panel.title .Draftail-Editor .public-DraftEditor-content:not(:hover, :focus, [aria-invalid=true]),
 .w-panel.title input:not(:hover, :focus, [aria-invalid=true]),
@@ -35,5 +36,5 @@
 .w-panel.title .Draftail-Editor .public-DraftEditor-content:not(:hover, :focus, [aria-invalid=true]),
 .w-panel.title input:not(:hover, :focus, [aria-invalid=true]),
 .w-panel.title textarea:not(:hover, :focus, [aria-invalid=true]) {
- border-color:#0000
+    border-color:#0000
 }


### PR DESCRIPTION
## Fixes: 
- #414 - Simple fix
- #415 - CSS issue
- #416 - Logic error

## Notes
1. Please test, I don't have the time. 
2. Includes passing `classname = "title"` to `FieldPanel` for consistent styling.