### PR TITLE
Various patches to "Page copy" (main being Alias functionality)

### DIFF
--- a/wagtail_modeltranslation/patch_wagtailadmin_actions.py
+++ b/wagtail_modeltranslation/patch_wagtailadmin_actions.py
@@ -1,0 +1,62 @@
+from wagtail.actions.create_alias import CreatePageAliasAction
+
+
+class PatchedCreatePageAliasAction(CreatePageAliasAction):
+    def __init__(
+        self,
+        page,
+        *,
+        recursive=False,
+        parent=None,
+        update_attrs=None, # Changed to support translated slugs
+        update_locale=None,
+        user=None,
+        log_action="wagtail.create_alias",
+        reset_translation_key=True,
+        _mpnode_attrs=None,
+    ):
+        self.attrs = update_attrs
+
+        super().__init__(
+            page,
+            recursive=recursive,
+            parent=parent,
+            update_slug="prova",
+            update_locale=update_locale,
+            user=user,
+            log_action=log_action,
+            reset_translation_key=reset_translation_key,
+            _mpnode_attrs=_mpnode_attrs,
+        )
+
+    def _create_alias(
+        self,
+        page,
+        *,
+        recursive,
+        parent,
+        update_slug,
+        update_locale,
+        user,
+        log_action,
+        reset_translation_key,
+        _mpnode_attrs,
+    ):
+        alias = super()._create_alias(
+            page,
+            recursive=recursive,
+            parent=parent,
+            update_slug=update_slug,
+            update_locale=update_locale,
+            user=user,
+            log_action=log_action,
+            reset_translation_key=reset_translation_key,
+            _mpnode_attrs=_mpnode_attrs,
+        )
+
+        for attr in self.attrs:
+            if "slug" in attr:
+                setattr(alias, attr, self.attrs[attr])
+
+        alias.save()
+        return alias

--- a/wagtail_modeltranslation/patch_wagtailadmin_forms.py
+++ b/wagtail_modeltranslation/patch_wagtailadmin_forms.py
@@ -46,6 +46,7 @@ class PatchedCopyForm(CopyForm):
                     label=locale_label,
                     required=not localized_field.blank,
                     allow_unicode=allow_unicode,
+                    widget=widgets.SlugInput,
                 )
         else:
             self.fields["new_slug"] = forms.SlugField(

--- a/wagtail_modeltranslation/patch_wagtailadmin_forms.py
+++ b/wagtail_modeltranslation/patch_wagtailadmin_forms.py
@@ -90,7 +90,7 @@ class PatchedCopyForm(CopyForm):
                     ) % {"count": pages_to_publish_count}
 
                 self.fields["publish_copies"] = forms.BooleanField(
-                    required=False, initial=True, label=label, help_text=help_text
+                    required=False, initial=False, label=label, help_text=help_text
                 )
 
     def clean(self):

--- a/wagtail_modeltranslation/patch_wagtailadmin_forms.py
+++ b/wagtail_modeltranslation/patch_wagtailadmin_forms.py
@@ -113,13 +113,13 @@ class PatchedCopyForm(CopyForm):
 
         # check if user is allowed to create a page at given location.
         if not parent_page.permissions_for_user(self.user).can_add_subpage():
-            raise ValidationError(
-                {
-                    "new_parent_page": _(
-                        'You do not have permission to copy to page "%(page_title)s"'
-                    )
-                    % {"page_title": parent_page.get_admin_display_title()}
-                }
+            self._errors["new_parent_page"] = self.error_class(
+                [
+                    _('You do not have permission to copy to page "%(page_title)s"')
+                    % {
+                        "page_title": parent_page.specific_deferred.get_admin_display_title()
+                    }
+                ]
             )
 
         # Count the pages with the same slug within the context of our copy's parent page
@@ -132,25 +132,21 @@ class PatchedCopyForm(CopyForm):
             activate(code)
             children_slugs = [child.slug for child in parent_page.get_children()]
             if slug and slug in children_slugs:
-                slug_errors[locale_slug] = _(
-                    'This slug is already in use within the context of its parent page "%s"'
-                    % parent_page
+                self._errors[locale_slug] = self.error_class(
+                    [
+                        _('This slug is already in use within the context of its parent page "%(parent_page_title)s"')
+                        % {"parent_page_title": parent_page}
+                    ]
                 )
         # back to current lang
         activate(current_lang)
-        if slug_errors:
-            raise ValidationError(slug_errors)
 
         # Don't allow recursive copies into self
         if cleaned_data.get("copy_subpages") and (
             self.page == parent_page or parent_page.is_descendant_of(self.page)
         ):
-            raise ValidationError(
-                {
-                    "new_parent_page": _(
-                        "You cannot copy a page into itself when copying subpages"
-                    )
-                }
+            self._errors["new_parent_page"] = self.error_class(
+                [_("You cannot copy a page into itself when copying subpages")]
             )
 
         return cleaned_data

--- a/wagtail_modeltranslation/patch_wagtailadmin_forms.py
+++ b/wagtail_modeltranslation/patch_wagtailadmin_forms.py
@@ -34,6 +34,7 @@ class PatchedCopyForm(CopyForm):
                 required=not localized_field.blank,
             )
 
+        allow_unicode = getattr(settings, "WAGTAIL_ALLOW_UNICODE_SLUGS", True)
         if wmt_settings.TRANSLATE_SLUGS:
             for code, name in settings.LANGUAGES:
                 localized_fieldname = build_localized_fieldname("slug", code)
@@ -44,6 +45,7 @@ class PatchedCopyForm(CopyForm):
                     initial=getattr(self.page, localized_fieldname),
                     label=locale_label,
                     required=not localized_field.blank,
+                    allow_unicode=allow_unicode,
                 )
         else:
             self.fields["new_slug"] = forms.SlugField(

--- a/wagtail_modeltranslation/patch_wagtailadmin_forms.py
+++ b/wagtail_modeltranslation/patch_wagtailadmin_forms.py
@@ -93,6 +93,15 @@ class PatchedCopyForm(CopyForm):
                     required=False, initial=False, label=label, help_text=help_text
                 )
 
+            # Note that only users who can publish in the new parent page can create an alias.
+            # This is because alias pages must always match their original page's state.
+            self.fields["alias"] = forms.BooleanField(
+                required=False,
+                initial=False,
+                label=_("Alias"),
+                help_text=_("Keep the new pages updated with future changes"),
+            )
+
     def clean(self):
         cleaned_data = super(CopyForm, self).clean()
 


### PR DESCRIPTION
The following code restores the "Alias" functionality to the "copy page" option

Here's a list of all that's been added:

- [X] Support Unicode slugs
- [X] Set `SlugWidget` as the translated-slug field's widget
- [X] Show "Alias" checkbox and implement its functionality (Solves #343)

The current solution is a bit hacky so I'm opening this as a Draft PR in hope someone has additional insight.