### PR TITLE
fix crash with `WAGTAILADMIN_COMMENTS_ENABLED = False`

### DIFF
--- a/wagtail_modeltranslation/patch_wagtailadmin.py
+++ b/wagtail_modeltranslation/patch_wagtailadmin.py
@@ -188,7 +188,10 @@ class WagtailTranslator(object):
             if isinstance(panel, PanelPlaceholder):
                 # Create an instance of the panel according to the specs of the placeholder
                 real_panel = panel.construct()
-                initiated_panels_list.append(real_panel)
+                # `real_panel` will be none for the `CommentPanelPlaceholder` subclass if
+                # `WAGTAILADMIN_COMMENTS_ENABLED = False` is set in the settings
+                if real_panel is not None:
+                    initiated_panels_list.append(real_panel)
             elif isinstance(panel, str):
                 field = current_patching_model._meta.get_field(panel)
                 if isinstance(field, ManyToOneRel):


### PR DESCRIPTION
This fixes a regression introduced in #456 that results in crash when the project is configured with `WAGTAILADMIN_COMMENTS_ENABLED = False`, resulting in the following traceback:

```python-traceback
Traceback (most recent call last):
  File "/home/joren/.local/share/uv/python/cpython-3.13-linux-x86_64-gnu/lib/python3.13/threading.py", line 1043, in _bootstrap_inner
    self.run()
    ~~~~~~~~^^
  File "/home/joren/.local/share/uv/python/cpython-3.13-linux-x86_64-gnu/lib/python3.13/threading.py", line 994, in run
    self._target(*self._args, **self._kwargs)
    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/joren/dev/bouncy_castles/.venv/lib/python3.13/site-packages/django/utils/autoreload.py", line 64, in wrapper
    fn(*args, **kwargs)
    ~~^^^^^^^^^^^^^^^^^
  File "/home/joren/dev/bouncy_castles/.venv/lib/python3.13/site-packages/django/core/management/commands/runserver.py", line 134, in inner_run
    self.check(**check_kwargs)
    ~~~~~~~~~~^^^^^^^^^^^^^^^^
  File "/home/joren/dev/bouncy_castles/.venv/lib/python3.13/site-packages/django/core/management/base.py", line 492, in check
    all_issues = checks.run_checks(
        app_configs=app_configs,
    ...<2 lines>...
        databases=databases,
    )
  File "/home/joren/dev/bouncy_castles/.venv/lib/python3.13/site-packages/django/core/checks/registry.py", line 89, in run_checks
    new_errors = check(app_configs=app_configs, databases=databases)
  File "/home/joren/dev/bouncy_castles/.venv/lib/python3.13/site-packages/wagtail/admin/checks.py", line 69, in get_form_class_check
    edit_handler = cls.get_edit_handler()
  File "/home/joren/dev/bouncy_castles/.venv/lib/python3.13/site-packages/wagtail/utils/decorators.py", line 54, in __call__
    return self.value
           ^^^^^^^^^^
  File "/home/joren/dev/bouncy_castles/.venv/lib/python3.13/site-packages/django/utils/functional.py", line 47, in __get__
    res = instance.__dict__[self.name] = self.func(instance)
                                         ~~~~~~~~~^^^^^^^^^^
  File "/home/joren/dev/bouncy_castles/.venv/lib/python3.13/site-packages/wagtail/utils/decorators.py", line 50, in value
    return self.fn(self.cls)
           ~~~~~~~^^^^^^^^^^
  File "/home/joren/dev/bouncy_castles/.venv/lib/python3.13/site-packages/wagtail/admin/panels/page_utils.py", line 35, in _get_page_edit_handler
    return edit_handler.bind_to_model(cls)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^
  File "/home/joren/dev/bouncy_castles/.venv/lib/python3.13/site-packages/wagtail/admin/panels/base.py", line 146, in bind_to_model
    new.on_model_bound()
    ~~~~~~~~~~~~~~~~~~^^
  File "/home/joren/dev/bouncy_castles/.venv/lib/python3.13/site-packages/wagtail/admin/panels/group.py", line 77, in on_model_bound
    self.children = [child.bind_to_model(self.model) for child in child_panels]
                     ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^
  File "/home/joren/dev/bouncy_castles/.venv/lib/python3.13/site-packages/wagtail/admin/panels/base.py", line 146, in bind_to_model
    new.on_model_bound()
    ~~~~~~~~~~~~~~~~~~^^
  File "/home/joren/dev/bouncy_castles/.venv/lib/python3.13/site-packages/wagtail/admin/panels/group.py", line 76, in on_model_bound
    child_panels = expand_panel_list(self.model, self.children)
  File "/home/joren/dev/bouncy_castles/.venv/lib/python3.13/site-packages/wagtail/admin/panels/model_utils.py", line 80, in expand_panel_list
    raise ImproperlyConfigured(
    ...<2 lines>...
    )
django.core.exceptions.ImproperlyConfigured: Invalid panel definition None - expected Panel or string, got <class 'NoneType'>
```

With this change, this crash no longer occurs.