### PR TITLE
Support field names with spaces/underscore.

### DIFF
--- a/wagtail_modeltranslation/static/wagtail_modeltranslation/js/copy_stream_fields.js
+++ b/wagtail_modeltranslation/static/wagtail_modeltranslation/js/copy_stream_fields.js
@@ -56,7 +56,8 @@ function extractInputId(currentStreamField) {
   }
 	var parts = panelId.split('-'); // Splitting the string by the delimiter '-'
 	var result = parts[3]; // Getting the forth part which is "stream1_pt" in the example
-	return result.split("_");
+	var splitAt = result.lastIndexOf('_');
+	return [result.substring(0, splitAt), result.substring(splitAt + 1)];
 }
 
 /* Copy the content of originID field to the targetID field */


### PR DESCRIPTION
Hi,

We ran into trouble with a streaming field called "optional sections". `extractInputId()` returns `['optional', 'sections', 'nl']` and the `fieldLang` ends up being `sections` instead of `nl`.
The change splits on the last `_` only so `extractInputId()` returns `['optional_sections', 'nl']`.

cheers,
Yvan